### PR TITLE
Show API timestamps in local time

### DIFF
--- a/lib/services/api_time.dart
+++ b/lib/services/api_time.dart
@@ -1,0 +1,44 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+/// The generated client hands back every `DateTime` in UTC - its serializer
+/// calls `toUtc()` on deserialize. The UI reads calendar fields and compares
+/// against `DateTime.now()`, so DTOs are converted to local time here, where
+/// they enter the app. `Date` fields carry no time zone and are left alone.
+class ApiTime {
+  const ApiTime._();
+
+  static AgendaEntryDto agendaEntry(AgendaEntryDto a) => a.rebuild((b) => b
+    ..date = a.date.toLocal()
+    ..endDate = a.endDate?.toLocal());
+
+  static List<AgendaEntryDto> agenda(Iterable<AgendaEntryDto> entries) =>
+      entries.map(agendaEntry).toList(growable: false);
+
+  static AbsenceDto absence(AbsenceDto a) => a.rebuild((b) => b
+    ..from = a.from.toLocal()
+    ..until = a.until.toLocal());
+
+  static List<AbsenceDto> absences(Iterable<AbsenceDto> list) =>
+      list.map(absence).toList(growable: false);
+
+  static StudentDocumentDto document(StudentDocumentDto d) => d.rebuild((b) => b
+    ..notifiedAt = d.notifiedAt?.toLocal()
+    ..createdAt = d.createdAt?.toLocal());
+
+  static List<StudentDocumentDto> documents(Iterable<StudentDocumentDto> list) =>
+      list.map(document).toList(growable: false);
+
+  static ClassDto schoolClass(ClassDto c) {
+    final agenda = c.agenda;
+    if (agenda == null) return c;
+    return c.rebuild((b) => b..agenda = ListBuilder<AgendaEntryDto>(agenda.map(agendaEntry)));
+  }
+
+  static List<ClassDto> classes(Iterable<ClassDto> list) =>
+      list.map(schoolClass).toList(growable: false);
+
+  /// A date-only value sent to the API: the picked calendar day, pinned to UTC
+  /// midnight so the day survives the round trip.
+  static DateTime utcDate(DateTime d) => DateTime.utc(d.year, d.month, d.day);
+}

--- a/lib/services/private_data_adapter.dart
+++ b/lib/services/private_data_adapter.dart
@@ -7,7 +7,7 @@ class PrivateDataAdapter {
   static const privateSchoolUserId = 'private-self';
 
   static DateTime? _date(String? s) =>
-      (s == null || s.isEmpty) ? null : DateTime.tryParse(s);
+      (s == null || s.isEmpty) ? null : DateTime.tryParse(s)?.toLocal();
 
   static DateTime _dateOr(String? s, DateTime fallback) => _date(s) ?? fallback;
 

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -4,6 +4,7 @@ import 'package:schuly_api/schuly_api.dart';
 
 import 'active_account_service.dart';
 import 'api_client.dart';
+import 'api_time.dart';
 import 'app_mode_service.dart';
 import 'private_account_store.dart';
 import 'private_data_adapter.dart';
@@ -99,23 +100,20 @@ class SchoolDataService extends ChangeNotifier {
       };
       final meId = _me?.id;
       final agenda = await _api.getAgendasApi().apiAgendasGet();
-      _agenda = (agenda.data ?? BuiltList<AgendaEntryDto>())
+      _agenda = ApiTime.agenda((agenda.data ?? BuiltList<AgendaEntryDto>())
           .where((a) =>
               (meId != null && a.schoolUserId == meId) ||
               a.entryType == AgendaEntryType.holiday ||
               myClassIds.isEmpty ||
-              myClassIds.contains(a.classId))
-          .toList(growable: false);
+              myClassIds.contains(a.classId)));
 
       final absences = await _api.getAbsencesApi().apiAbsencesGet();
-      _absences = (absences.data ?? BuiltList<AbsenceDto>())
-          .where((a) => a.schoolId == schoolId)
-          .toList(growable: false);
+      _absences = ApiTime.absences(
+          (absences.data ?? BuiltList<AbsenceDto>()).where((a) => a.schoolId == schoolId));
 
       final classes = await _api.getClassApi().apiClassGet();
-      _classes = (classes.data ?? BuiltList<ClassDto>())
-          .where((c) => c.schoolId == schoolId)
-          .toList(growable: false);
+      _classes = ApiTime.classes(
+          (classes.data ?? BuiltList<ClassDto>()).where((c) => c.schoolId == schoolId));
 
       final reports = await _api.getSemesterReportsApi().apiSemesterReportsGet();
       _reports = (reports.data ?? BuiltList<SemesterReportDto>())
@@ -128,9 +126,8 @@ class SchoolDataService extends ChangeNotifier {
           .toList(growable: false);
 
       final documents = await _api.getStudentDocumentsApi().apiDocumentsGet();
-      _documents = (documents.data ?? BuiltList<StudentDocumentDto>())
-          .where((d) => meId == null || d.schoolUserId == meId)
-          .toList(growable: false);
+      _documents = ApiTime.documents((documents.data ?? BuiltList<StudentDocumentDto>())
+          .where((d) => meId == null || d.schoolUserId == meId));
     } catch (e) {
       _error = e;
     } finally {

--- a/lib/ui/absences/absences_page.dart
+++ b/lib/ui/absences/absences_page.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import 'package:schuly_api/schuly_api.dart';
 
 import '../../services/api_client.dart';
+import '../../services/api_time.dart';
 import '../../services/school_data_service.dart';
 
 class AbsencesPage extends StatelessWidget {
@@ -156,8 +157,8 @@ class _AbsenceFormState extends State<_AbsenceForm> {
           createAbsenceCommand: CreateAbsenceCommand((b) => b
             ..reason = _reason.text.trim()
             ..type = _type
-            ..from = _from.toUtc()
-            ..until = _until.toUtc()
+            ..from = ApiTime.utcDate(_from)
+            ..until = ApiTime.utcDate(_until)
             ..schoolUserId = schoolUserId),
         );
       } else {
@@ -166,8 +167,8 @@ class _AbsenceFormState extends State<_AbsenceForm> {
             ..absenceId = existing.id
             ..reason = _reason.text.trim()
             ..type = _type
-            ..from = _from.toUtc()
-            ..until = _until.toUtc()
+            ..from = ApiTime.utcDate(_from)
+            ..until = ApiTime.utcDate(_until)
             ..schoolUserId = existing.schoolUserId),
         );
       }

--- a/lib/ui/classes/class_detail_screen.dart
+++ b/lib/ui/classes/class_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:schuly_api/schuly_api.dart';
 
 import '../../config/oidc_config.dart';
 import '../../services/api_client.dart';
+import '../../services/api_time.dart';
 import '../core/grade_color.dart';
 
 class ClassDetailScreen extends StatefulWidget {
@@ -35,7 +36,8 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
       final res = await ApiClient.instance.api
           .getClassApi()
           .apiClassSearchGet(classId: widget.classId);
-      if (mounted) setState(() => _class = res.data);
+      final data = res.data;
+      if (mounted) setState(() => _class = data == null ? null : ApiTime.schoolClass(data));
     } catch (e) {
       if (mounted) setState(() => _error = e);
     } finally {

--- a/test/api_time_test.dart
+++ b/test/api_time_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/domain/private_data.dart';
+import 'package:schuly/services/api_time.dart';
+import 'package:schuly/services/private_data_adapter.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+void main() {
+  group('ApiTime.agendaEntry', () {
+    test('converts a UTC date and endDate to local, preserving the instant', () {
+      final utcDate = DateTime.utc(2024, 3, 1, 7, 15);
+      final utcEndDate = DateTime.utc(2024, 3, 1, 8, 0);
+      final entry = AgendaEntryDto((b) => b
+        ..entryType = AgendaEntryType.lesson
+        ..title = 'Math'
+        ..date = utcDate
+        ..endDate = utcEndDate);
+
+      final result = ApiTime.agendaEntry(entry);
+
+      expect(result.date.isUtc, isFalse);
+      expect(result.date.millisecondsSinceEpoch, utcDate.millisecondsSinceEpoch);
+      expect(result.date, utcDate.toLocal());
+
+      expect(result.endDate, isNotNull);
+      expect(result.endDate!.isUtc, isFalse);
+      expect(result.endDate!.millisecondsSinceEpoch, utcEndDate.millisecondsSinceEpoch);
+      expect(result.endDate, utcEndDate.toLocal());
+    });
+
+    test('leaves a null endDate null', () {
+      final utcDate = DateTime.utc(2024, 3, 1, 7, 15);
+      final entry = AgendaEntryDto((b) => b
+        ..entryType = AgendaEntryType.lesson
+        ..title = 'Math'
+        ..date = utcDate);
+
+      final result = ApiTime.agendaEntry(entry);
+
+      expect(result.endDate, isNull);
+    });
+  });
+
+  group('ApiTime.absence', () {
+    test('converts from and until to local, preserving the instant', () {
+      final utcFrom = DateTime.utc(2024, 2, 28, 23, 0);
+      final utcUntil = DateTime.utc(2024, 3, 1, 23, 0);
+      final absence = AbsenceDto((b) => b
+        ..reason = 'Sick'
+        ..type = AbsenceType.absence
+        ..from = utcFrom
+        ..until = utcUntil);
+
+      final result = ApiTime.absence(absence);
+
+      expect(result.from.isUtc, isFalse);
+      expect(result.from.millisecondsSinceEpoch, utcFrom.millisecondsSinceEpoch);
+      expect(result.from, utcFrom.toLocal());
+
+      expect(result.until.isUtc, isFalse);
+      expect(result.until.millisecondsSinceEpoch, utcUntil.millisecondsSinceEpoch);
+      expect(result.until, utcUntil.toLocal());
+    });
+  });
+
+  group('ApiTime.schoolClass', () {
+    test('converts nested agenda entries', () {
+      final utcDate = DateTime.utc(2024, 3, 1, 7, 15);
+      final entry = AgendaEntryDto((b) => b
+        ..entryType = AgendaEntryType.lesson
+        ..title = 'Math'
+        ..date = utcDate);
+      final schoolClass = ClassDto((b) => b
+        ..name = 'Class A'
+        ..agenda.replace([entry]));
+
+      final result = ApiTime.schoolClass(schoolClass);
+
+      expect(result.agenda, isNotNull);
+      expect(result.agenda!.single.date.isUtc, isFalse);
+      expect(result.agenda!.single.date, utcDate.toLocal());
+    });
+
+    test('leaves a null agenda null', () {
+      final schoolClass = ClassDto((b) => b..name = 'Class A');
+
+      final result = ApiTime.schoolClass(schoolClass);
+
+      expect(result.agenda, isNull);
+    });
+  });
+
+  group('ApiTime.utcDate', () {
+    test('pins a local calendar day to UTC midnight', () {
+      final input = DateTime(2024, 3, 1, 13, 30);
+      final result = ApiTime.utcDate(input);
+
+      expect(result, DateTime.utc(2024, 3, 1));
+      expect(result.isUtc, isTrue);
+      expect(result.hour, 0);
+      expect(result.minute, 0);
+      expect(result.year, input.year);
+      expect(result.month, input.month);
+      expect(result.day, input.day);
+    });
+  });
+
+  group('PrivateDataAdapter', () {
+    test('agendaEntry produces a local, instant-preserving date', () {
+      final event = PrivateAgendaEvent(
+        id: '1',
+        title: 'History',
+        startDate: '2024-03-01T07:15:00Z',
+        endDate: '2024-03-01T08:00:00Z',
+      );
+
+      final result = PrivateDataAdapter.agendaEntry(event);
+
+      final expected = DateTime.parse('2024-03-01T07:15:00Z');
+      expect(result.date.isUtc, isFalse);
+      expect(result.date.millisecondsSinceEpoch, expected.millisecondsSinceEpoch);
+
+      final expectedEnd = DateTime.parse('2024-03-01T08:00:00Z');
+      expect(result.endDate!.isUtc, isFalse);
+      expect(result.endDate!.millisecondsSinceEpoch, expectedEnd.millisecondsSinceEpoch);
+    });
+
+    test('absence produces local, instant-preserving from/until', () {
+      final privateAbsence = PrivateAbsence(
+        id: '1',
+        from: '2024-03-01T00:00:00Z',
+        to: '2024-03-02T00:00:00Z',
+        reason: 'Sick',
+      );
+
+      final result = PrivateDataAdapter.absence(privateAbsence);
+
+      final expectedFrom = DateTime.parse('2024-03-01T00:00:00Z');
+      final expectedUntil = DateTime.parse('2024-03-02T00:00:00Z');
+      expect(result.from.isUtc, isFalse);
+      expect(result.from.millisecondsSinceEpoch, expectedFrom.millisecondsSinceEpoch);
+      expect(result.until.isUtc, isFalse);
+      expect(result.until.millisecondsSinceEpoch, expectedUntil.millisecondsSinceEpoch);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Convert every API `DateTime` to local time once, where the DTOs enter the app, instead of letting the UI read UTC calendar fields. The generated client's `Iso8601DateTimeSerializer` calls `toUtc()` on deserialize, so an 08:00 lesson rendered as 06:00/07:00 and anything before 01:00/02:00 local landed on the previous day in Home and Timetable.
- New `ApiTime` helper normalises agenda entries, absences, classes (nested agenda) and student documents; `SchoolDataService` runs the account-mode lists through it and `ClassDetailScreen` normalises the class it loads directly.
- The private-mode adapter now produces the same kind: `DateTime.tryParse(...)?.toLocal()` instead of a value whose kind depended on whether the source string carried a `Z`.
- Absences are date-only, so the form now sends `DateTime.utc(y, m, d)` rather than local midnight converted with `toUtc()` - a day reported for 1 March no longer comes back as 28 February.
- Unit tests for the conversion helpers and the private adapter, written to pass in any machine time zone.

Closes #475
