### PR TITLE
Harden private-mode refresh, account actions and server setup

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         // OIDC redirect scheme for flutter_appauth's RedirectUriReceiverActivity.
-        // Must match the backend's redirect URI scheme (schulytest://callback).
+        // Must match OidcConfig.redirectScheme (lib/config/oidc_config.dart).
         manifestPlaceholders["appAuthRedirectScheme"] = "schulytest"
     }
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,8 +50,8 @@
 	<!-- OIDC (account mode) returns to the app via the backend's custom
 	     redirect scheme (schulytest://callback), driven by flutter_appauth over
 	     ASWebAuthenticationSession. Registering it here lets iOS route the login
-	     callback back into the app. The scheme matches the backend's redirectUri
-	     / OidcConfig fallback. -->
+	     callback back into the app. Must match OidcConfig.redirectScheme
+	     (lib/config/oidc_config.dart). -->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -34,6 +34,10 @@ class OidcSettings {
   /// derived from [redirectUri] so the app never hardcodes it.
   String get callbackScheme => Uri.parse(redirectUri).scheme;
 
+  /// Whether the browser can actually return here - the provider's redirect
+  /// scheme has to be the one registered by the platform projects.
+  bool get schemeIsRegistered => callbackScheme == OidcConfig.redirectScheme;
+
   /// Whether the OIDC endpoints use plaintext `http://` (a self-hosted / local
   /// backend). flutter_appauth rejects http unless told to allow it, so this
   /// gates `allowInsecureConnections`; https providers stay strict.
@@ -41,6 +45,13 @@ class OidcSettings {
 }
 
 class OidcConfig {
+  /// The deep-link scheme compiled into the platform projects - Android's
+  /// `appAuthRedirectScheme` manifest placeholder and iOS's `CFBundleURLSchemes`.
+  /// A self-hosted backend must hand out a `redirectUri` on this scheme
+  /// (`schulytest://callback`); anything else cannot return to the app, so
+  /// `AuthService.signIn` rejects it rather than hanging on the browser.
+  static const redirectScheme = 'schulytest';
+
   static String get backendBaseUrl => BackendConfig.url;
 
   static OidcSettings? _settings;
@@ -74,7 +85,7 @@ class OidcConfig {
       clientId: app['clientId'] as String,
       scope: (app['scope'] as String?) ??
           'openid profile email groups picture offline_access',
-      redirectUri: (app['redirectUri'] as String?) ?? 'schulytest://callback',
+      redirectUri: (app['redirectUri'] as String?) ?? '$redirectScheme://callback',
       authorizationEndpoint: disco['authorization_endpoint'] as String,
       tokenEndpoint: disco['token_endpoint'] as String,
       endSessionEndpoint: disco['end_session_endpoint'] as String?,

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -127,11 +127,24 @@ class ActiveAccountService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> removeSchool(MySchool school) async {
-    final accountId = school.pluginAccountId;
+  /// Resolves a school's plugin account, re-running detection when the id is
+  /// missing - startup detection is best-effort and can fail transiently.
+  Future<({String accountId, String basePath})?> resolvePluginTarget(MySchool school) async {
+    final id = school.pluginAccountId;
     final base = school.pluginBasePath;
-    if (accountId == null || base == null || base.isEmpty) return;
-    await ApiClient.instance.dio.delete<dynamic>('$base/accounts/$accountId');
+    if (id != null && base != null && base.isNotEmpty) return (accountId: id, basePath: base);
+    final detected = (await _detectPluginAccounts())[school.id];
+    final detectedBase = detected?.pluginBasePath;
+    if (detected == null || detectedBase == null || detectedBase.isEmpty) return null;
+    return (accountId: detected.accountId, basePath: detectedBase);
+  }
+
+  Future<void> removeSchool(MySchool school) async {
+    final target = await resolvePluginTarget(school);
+    if (target == null) {
+      throw Exception('Could not resolve the connected account for ${school.name}. Check your connection and try again.');
+    }
+    await ApiClient.instance.dio.delete<dynamic>('${target.basePath}/accounts/${target.accountId}');
     if (_activeId == school.id) {
       _activeId = null;
       final prefs = await SharedPreferences.getInstance();

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -73,6 +73,9 @@ class AuthService {
   /// registration screen first.
   static Future<AuthTokens> signIn({bool register = false}) async {
     final cfg = await OidcConfig.settings();
+    if (!cfg.schemeIsRegistered) {
+      throw Exception('This backend redirects to ${cfg.callbackScheme}://, which this app build cannot receive. Configure its redirect URI as ${OidcConfig.redirectScheme}://callback.');
+    }
     final result = await _appAuth.authorizeAndExchangeCode(
       AuthorizationTokenRequest(
         cfg.clientId,

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -152,9 +152,6 @@ class SchoolDataService extends ChangeNotifier {
     try {
       if (account.accessToken != null) {
         final d = await TokenProxyClient.instance.fetchAll(account);
-        if (d.refreshedAccount != null) {
-          await PrivateAccountStore.instance.save(d.refreshedAccount!);
-        }
         _me = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, d.absences);
         _exams = PrivateDataAdapter.exams(d.exams);
         _absences = PrivateDataAdapter.absencesList(d.absences);

--- a/lib/services/token_proxy_client.dart
+++ b/lib/services/token_proxy_client.dart
@@ -98,17 +98,18 @@ class TokenProxyClient {
 
   Future<TokenPrivateData> fetchAll(PrivateAccount account) async {
     try {
-      return await _fetchAll(account, null);
+      return await _fetchAll(account);
     } on DioException catch (e) {
       if (e.response?.statusCode != 401) rethrow;
       final refreshed = await _refreshAccount(account);
       if (refreshed == null) rethrow;
-      return await _fetchAll(refreshed, refreshed);
+      // Persist the rotated context_state before fetching, so a failing fetch cannot drop it.
+      await PrivateAccountStore.instance.save(refreshed);
+      return await _fetchAll(refreshed);
     }
   }
 
-  Future<TokenPrivateData> _fetchAll(
-      PrivateAccount a, PrivateAccount? refreshed) async {
+  Future<TokenPrivateData> _fetchAll(PrivateAccount a) async {
     final info = await userInfo(a);
     final g = await grades(a);
     final e = await exams(a);
@@ -120,7 +121,6 @@ class TokenProxyClient {
       exams: e,
       absences: ab,
       agenda: ag,
-      refreshedAccount: refreshed,
     );
   }
 
@@ -131,13 +131,17 @@ class TokenProxyClient {
   /// Schuly regenerates the OTP itself, so the user is never prompted.
   Future<PrivateAccount?> _refreshAccount(PrivateAccount a) async {
     if (a.contextState != null) {
-      final r = await refresh(
-        basePath: a.statelessBasePath,
-        baseUrl: a.baseUrl,
-        userAgent: a.userAgent ?? '',
-        contextState: a.contextState!,
-      );
-      if (r.success && r.accessToken != null) return _applied(a, r);
+      try {
+        final r = await refresh(
+          basePath: a.statelessBasePath,
+          baseUrl: a.baseUrl,
+          userAgent: a.userAgent ?? '',
+          contextState: a.contextState!,
+        );
+        if (r.success && r.accessToken != null) return _applied(a, r);
+      } on DioException {
+        // An HTTP failure falls through to the credential relogin below.
+      }
     }
     return _credentialRelogin(a);
   }
@@ -148,15 +152,20 @@ class TokenProxyClient {
     if (email == null || email.isEmpty || password == null || password.isEmpty) {
       return null;
     }
-    final r = await login(
-      basePath: a.statelessBasePath,
-      baseUrl: a.baseUrl,
-      email: email,
-      password: password,
-      totpSecret: TotpService.secretOf(a.totpSecret),
-    );
-    if (!r.success || r.accessToken == null) return null;
-    return _applied(a, r);
+    try {
+      final r = await login(
+        basePath: a.statelessBasePath,
+        baseUrl: a.baseUrl,
+        email: email,
+        password: password,
+        totpSecret: TotpService.secretOf(a.totpSecret),
+      );
+      if (!r.success || r.accessToken == null) return null;
+      return _applied(a, r);
+    } on DioException {
+      // Let the caller rethrow the original 401 instead of this one.
+      return null;
+    }
   }
 
   PrivateAccount _applied(PrivateAccount a, PrivateRefreshResult r) =>
@@ -199,13 +208,11 @@ class TokenPrivateData {
   final List<PrivateExam> exams;
   final List<PrivateAbsence> absences;
   final List<PrivateAgendaEvent> agenda;
-  final PrivateAccount? refreshedAccount;
   const TokenPrivateData({
     required this.userInfo,
     required this.grades,
     required this.exams,
     required this.absences,
     required this.agenda,
-    this.refreshedAccount,
   });
 }

--- a/lib/ui/absences/absences_page.dart
+++ b/lib/ui/absences/absences_page.dart
@@ -173,8 +173,10 @@ class _AbsenceFormState extends State<_AbsenceForm> {
       }
       if (mounted) Navigator.of(context).pop(true);
     } on DioException catch (e) {
+      if (!mounted) return;
       setState(() => _error = 'HTTP ${e.response?.statusCode}: ${e.response?.data}');
     } catch (e) {
+      if (!mounted) return;
       setState(() => _error = e.toString());
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -189,6 +191,7 @@ class _AbsenceFormState extends State<_AbsenceForm> {
       await ApiClient.instance.api.getAbsencesApi().apiAbsencesIdDelete(id: existing!.id!);
       if (mounted) Navigator.of(context).pop(true);
     } on DioException catch (e) {
+      if (!mounted) return;
       setState(() {
         _busy = false;
         _error = 'HTTP ${e.response?.statusCode}: ${e.response?.data}';

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -75,9 +75,13 @@ class _AccountPageState extends State<AccountPage> {
 
   Future<void> _syncNow() async {
     final active = ActiveAccountService.instance.active;
-    final accountId = active?.pluginAccountId;
-    final base = active?.pluginBasePath;
-    if (accountId == null || base == null || base.isEmpty) {
+    if (active == null) {
+      setState(() => _syncMsg = 'No connected account to sync');
+      return;
+    }
+    final target = await ActiveAccountService.instance.resolvePluginTarget(active);
+    if (target == null) {
+      if (!mounted) return;
       setState(() => _syncMsg = 'No connected account to sync');
       return;
     }
@@ -87,7 +91,7 @@ class _AccountPageState extends State<AccountPage> {
     });
     try {
       await ApiClient.instance.dio.post<dynamic>(
-        '$base/accounts/$accountId/sync',
+        '${target.basePath}/accounts/${target.accountId}/sync',
         options: ApiClient.handled(),
       );
       await SchoolDataService.instance.refresh();

--- a/lib/ui/account/unified_connect_screen.dart
+++ b/lib/ui/account/unified_connect_screen.dart
@@ -67,6 +67,7 @@ class _UnifiedConnectScreenState extends State<UnifiedConnectScreen> {
       TextInput.finishAutofillContext();
       if (mounted) Navigator.of(context).pop(accountId);
     } catch (e) {
+      if (!mounted) return;
       setState(() => _error = ApiError.describe(e));
     } finally {
       if (mounted) setState(() => _busy = false);

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -64,6 +64,7 @@ class _RootScreenState extends State<RootScreen> {
       await AuthService.signIn(register: register);
       await _refresh();
     } catch (e) {
+      if (!mounted) return;
       setState(() => _error = '$e');
     } finally {
       if (mounted) setState(() => _busy = false);

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import '../../../domain/my_school.dart';
 import '../../../services/active_account_service.dart';
 import '../../../services/app_mode_service.dart';
+import '../../../services/toast_service.dart';
 import '../../authenticator/authenticator_vault_screen.dart';
 import '../../settings/settings_screen.dart';
 import 'add_school_modal.dart';
@@ -46,7 +47,9 @@ class AccountsSidebar extends StatelessWidget {
     if (confirmed != true) return;
     try {
       await ActiveAccountService.instance.removeSchool(school);
-    } catch (_) {/* keep the sheet open; list reflects whatever succeeded */}
+    } catch (e) {
+      ToastService.error('Disconnect failed', e);
+    }
   }
 
   Future<void> _add(BuildContext context) async {

--- a/lib/ui/documents/documents_page.dart
+++ b/lib/ui/documents/documents_page.dart
@@ -4,11 +4,13 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 import 'package:open_filex/open_filex.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:schuly_api/schuly_api.dart';
 
 import '../../services/active_account_service.dart';
 import '../../services/api_client.dart';
+import '../../services/api_error.dart';
 import '../../services/school_data_service.dart';
 
 class DocumentsScreen extends StatefulWidget {
@@ -74,16 +76,26 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         '/api/documents/$id',
         options: Options(responseType: ResponseType.bytes),
       );
+      final bytes = res.data;
+      if (bytes == null) throw Exception('The server returned an empty document.');
       final dir = await getTemporaryDirectory();
-      final name = doc.fileName?.isNotEmpty == true ? doc.fileName! : 'document-$id';
-      final file = File('${dir.path}/$name');
-      await file.writeAsBytes(res.data ?? const []);
-      await OpenFilex.open(file.path);
+      // The server-supplied name is untrusted - keep its last segment only.
+      final base = p.basename(doc.fileName ?? '');
+      final unusable = base.isEmpty || base == '.' || base == '..' || p.isAbsolute(base);
+      final file = File(p.join(dir.path, unusable ? 'document-$id' : base));
+      await file.writeAsBytes(bytes);
+      final result = await OpenFilex.open(file.path);
+      if (result.type != ResultType.done && mounted) {
+        showFToast(
+          context: context,
+          title: Text('Could not open document: ${result.message}'),
+        );
+      }
     } catch (e) {
       if (mounted) {
         showFToast(
           context: context,
-          title: Text('Could not open document: $e'),
+          title: Text('Could not open document: ${ApiError.describe(e)}'),
         );
       }
     } finally {

--- a/lib/ui/onboarding/onboarding_screen.dart
+++ b/lib/ui/onboarding/onboarding_screen.dart
@@ -93,7 +93,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     }
     if (BackendConfig.isInsecure(raw)) {
       setState(() {
-        _serverError = 'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.';
+        _serverError = null;
         _serverOk = null;
       });
       return;
@@ -374,9 +374,9 @@ class _ServerPage extends StatelessWidget {
                 if (BackendConfig.isInsecure(urlController.text)) ...[
                   const SizedBox(height: 8),
                   Text(
-                    'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.',
+                    'Use https:// (http only works for localhost)',
                     textAlign: TextAlign.center,
-                    style: typography.xs.copyWith(color: colors.error),
+                    style: typography.xs.copyWith(color: colors.destructive),
                   ),
                 ],
               ],

--- a/lib/ui/onboarding/onboarding_screen.dart
+++ b/lib/ui/onboarding/onboarding_screen.dart
@@ -91,6 +91,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       });
       return;
     }
+    if (BackendConfig.isInsecure(raw)) {
+      setState(() {
+        _serverError = 'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.';
+        _serverOk = null;
+      });
+      return;
+    }
     setState(() {
       _probing = true;
       _serverError = null;
@@ -367,7 +374,7 @@ class _ServerPage extends StatelessWidget {
                 if (BackendConfig.isInsecure(urlController.text)) ...[
                   const SizedBox(height: 8),
                   Text(
-                    'Plaintext http:// - your login would be sent unencrypted. Use https:// unless this is a trusted local network.',
+                    'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.',
                     textAlign: TextAlign.center,
                     style: typography.xs.copyWith(color: colors.error),
                   ),

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -68,6 +68,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
         await _connectScrape(baseUrl, name, basePath);
       }
     } catch (e) {
+      if (!mounted) return;
       setState(() => _error = ApiError.describe(e));
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -87,6 +88,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       totpSecret: totpSecret,
     );
     if (!res.success || res.accessToken == null) {
+      if (!mounted) return;
       setState(() => _error = res.message ?? 'Login failed');
       return;
     }

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -191,6 +191,10 @@ class _ServerDialogState extends State<_ServerDialog> {
         setState(() => _error = 'Enter a valid http(s) URL.');
         return;
       }
+      if (BackendConfig.isInsecure(raw)) {
+        setState(() => _error = 'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.');
+        return;
+      }
       setState(() {
         _busy = true;
         _error = null;
@@ -285,7 +289,7 @@ class _ServerDialogState extends State<_ServerDialog> {
             if (BackendConfig.isInsecure(_urlCtrl.text)) ...[
               const SizedBox(height: 6),
               Text(
-                'Plaintext http:// - your login would be sent unencrypted. Use https:// unless this is a trusted local network.',
+                'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.',
                 style: typography.xs.copyWith(color: colors.error),
               ),
             ],

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -192,7 +192,7 @@ class _ServerDialogState extends State<_ServerDialog> {
         return;
       }
       if (BackendConfig.isInsecure(raw)) {
-        setState(() => _error = 'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.');
+        setState(() => _error = null);
         return;
       }
       setState(() {
@@ -289,8 +289,8 @@ class _ServerDialogState extends State<_ServerDialog> {
             if (BackendConfig.isInsecure(_urlCtrl.text)) ...[
               const SizedBox(height: 6),
               Text(
-                'Plaintext http:// is blocked by the platform. Use https:// - only localhost is exempt.',
-                style: typography.xs.copyWith(color: colors.error),
+                'Use https:// (http only works for localhost)',
+                style: typography.xs.copyWith(color: colors.destructive),
               ),
             ],
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -518,7 +518,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2
   forui: ^0.17.0
   forui_assets: ^0.17.1
+  path: ^1.9.0
   path_provider: ^2.1.2
   open_filex: ^4.5.0
   # On-device TOTP: generate the second factor from a vaulted seed.


### PR DESCRIPTION
## Summary

- Private mode: an HTTP failure from the stateless `/refresh` now falls through to the credential re-login instead of throwing, and the refreshed account (new token + rotated `contextState`) is persisted immediately after the refresh, before the data fetches, so a failing fetch can no longer drop the rotated state.
- Disconnecting a school resolves the plugin account lazily, retrying detection when the startup pass failed, and throws with a toast instead of silently doing nothing. "Sync now" uses the same lazy resolver.
- Document open checks the `OpenFilex` result and toasts its message, sanitises the server-supplied file name with `p.basename`, and fails on an empty response body instead of writing an empty file.
- Non-loopback `http://` backend URLs are rejected in the settings and onboarding server steps with an explicit message, replacing the misleading "Couldn't reach a Schuly backend at this URL".
- The compiled-in OIDC redirect scheme lives in one const (`OidcConfig.redirectScheme`); `signIn` rejects a backend whose `redirectUri` uses a different scheme instead of hanging on "Waiting for browser...".
- Added the missing `if (!mounted) return;` guards before `setState` in the connect, absence and sign-in async handlers.

Closes #480
Closes #482
Closes #483
Closes #485
Closes #486
Closes #487
Closes #495
