### PR TITLE
Keep the session through transient token-refresh failures

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -5,6 +5,8 @@ import 'auth_service.dart';
 import 'backend_dio.dart';
 import 'toast_service.dart';
 
+const _retried = '_retried';
+
 class ApiClient {
   ApiClient._() {
     _dio = backendDio(
@@ -25,24 +27,34 @@ class ApiClient {
           },
           onError: (e, handler) async {
             final options = e.requestOptions;
-            if (e.response?.statusCode == 401 && options.extra['_retried'] != true) {
-              final newToken = await _refresh();
-              if (newToken != null) {
-                options.extra['_retried'] = true;
-                options.headers['Authorization'] = 'Bearer $newToken';
-                try {
-                  return handler.resolve(await _dio.fetch(options));
-                } on DioException catch (retryError) {
-                  _toastHttpError(retryError);
-                  return handler.next(retryError);
-                }
-              }
-              ToastService.error('Session expired', 'Please sign in again.');
-              await AuthService.signOut();
+            if (e.response?.statusCode != 401) {
+              _toastHttpError(e);
               return handler.next(e);
             }
-            _toastHttpError(e);
-            handler.next(e);
+            // A 401 on the retry means the freshly minted access token was still
+            // refused - the session itself is gone, not just the old token.
+            if (options.extra[_retried] == true) {
+              await _endExpiredSession();
+              return handler.next(e);
+            }
+            final refresh = await _refresh();
+            final newToken = refresh.accessToken;
+            if (newToken != null) {
+              options.extra[_retried] = true;
+              options.headers['Authorization'] = 'Bearer $newToken';
+              try {
+                return handler.resolve(await _dio.fetch(options));
+              } on DioException catch (retryError) {
+                // The nested interceptor pass already reported this failure.
+                return handler.next(retryError);
+              }
+            }
+            if (refresh.failure == AuthFailure.transport) {
+              _toastNetworkError(e);
+              return handler.next(e);
+            }
+            await _endExpiredSession();
+            return handler.next(e);
           },
         ),
       ],
@@ -65,11 +77,21 @@ class ApiClient {
 
   Dio get dio => _dio;
 
-  Future<String?>? _refreshing;
+  Future<AuthRefresh>? _refreshing;
 
-  Future<String?> _refresh() {
+  Future<AuthRefresh> _refresh() {
     return _refreshing ??=
         AuthService.refreshAccessToken().whenComplete(() => _refreshing = null);
+  }
+}
+
+/// The session is over. Sign out locally - the browser logout page would be a
+/// jarring detour out of the app for something the user didn't ask for - and let
+/// RootScreen react to `sessionEpoch`. Only the call that actually ended the
+/// session toasts, so N concurrent 401s produce one message.
+Future<void> _endExpiredSession() async {
+  if (await AuthService.signOut(endSession: false)) {
+    ToastService.error('Session expired', 'Please sign in again.');
   }
 }
 
@@ -84,4 +106,9 @@ void _toastHttpError(DioException e) {
   } else {
     ToastService.error('Network error', "Couldn't reach the server.");
   }
+}
+
+void _toastNetworkError(DioException e) {
+  if (e.requestOptions.extra[ApiClient.handlesErrors] == true) return;
+  ToastService.error('Network error', "Couldn't reach the server. Please try again.");
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -15,6 +15,27 @@ class AuthTokens {
   AuthTokens({required this.accessToken, this.idToken, this.refreshToken, this.accessTokenExpiry});
 }
 
+/// Why a token refresh failed.
+enum AuthFailure {
+  /// The provider rejected the refresh token (`invalid_grant` and the other
+  /// OAuth error codes) - the session is over and the user has to sign in again.
+  auth,
+
+  /// The provider couldn't be reached (no network, timeout, 5xx, a malformed
+  /// response). The stored tokens are still good: retry, don't sign out.
+  transport,
+}
+
+/// Outcome of [AuthService.refreshAccessToken]: either a fresh access token or
+/// the reason it couldn't be minted.
+class AuthRefresh {
+  const AuthRefresh.token(String this.accessToken) : failure = null;
+  const AuthRefresh.failed(AuthFailure this.failure) : accessToken = null;
+
+  final String? accessToken;
+  final AuthFailure? failure;
+}
+
 /// OIDC Authorization Code + PKCE login backed by [FlutterAppAuth], which drives
 /// the flow through ASWebAuthenticationSession (iOS) / Chrome Custom Tabs
 /// (Android) - the system browser, never a WebView, and never an in-app
@@ -66,6 +87,25 @@ class AuthService {
 
   static AuthorizationServiceConfiguration _serviceConfig(OidcSettings cfg) => AuthorizationServiceConfiguration(authorizationEndpoint: cfg.authorizationEndpoint, tokenEndpoint: cfg.tokenEndpoint, endSessionEndpoint: cfg.endSessionEndpoint);
 
+  /// The standard OAuth 2.0 error codes. The provider reporting any of them
+  /// means it looked at the grant and refused it; everything else that can come
+  /// out of the token call (no network, a timeout, a 5xx, a parse failure) is
+  /// transport trouble and must not cost the user their session.
+  static const _oauthErrors = {
+    FlutterAppAuthOAuthError.invalidRequest,
+    FlutterAppAuthOAuthError.invalidClient,
+    FlutterAppAuthOAuthError.invalidGrant,
+    FlutterAppAuthOAuthError.unauthorizedClient,
+    FlutterAppAuthOAuthError.unsupportedGrantType,
+    FlutterAppAuthOAuthError.invalidScope,
+  };
+
+  @visibleForTesting
+  static AuthFailure classifyRefreshError(Object error) {
+    final oauthError = error is FlutterAppAuthPlatformException ? error.platformErrorDetails.error : null;
+    return _oauthErrors.contains(oauthError) ? AuthFailure.auth : AuthFailure.transport;
+  }
+
   /// Runs the OIDC Authorization Code + PKCE flow in the system browser and
   /// exchanges the code for tokens. flutter_appauth applies PKCE (S256)
   /// automatically. When [register] is true the authorize request carries
@@ -109,7 +149,7 @@ class AuthService {
     if (token != null && expiry != null && expiry.isAfter(DateTime.now().add(const Duration(seconds: 30)))) {
       return token;
     }
-    return refreshAccessToken();
+    return (await refreshAccessToken()).accessToken;
   }
 
   static Future<String?> getRefreshToken() async {
@@ -117,13 +157,17 @@ class AuthService {
     return _storage.read(key: _kRefreshTokenKey);
   }
 
-  static Future<String?>? _refreshing;
+  /// Whether a refresh token is stored - the app has a session it can re-mint an
+  /// access token from, even while it can't reach the provider.
+  static Future<bool> hasSession() async => await getRefreshToken() != null;
 
-  static Future<String?> refreshAccessToken() => _refreshing ??= _refresh().whenComplete(() => _refreshing = null);
+  static Future<AuthRefresh>? _refreshing;
 
-  static Future<String?> _refresh() async {
+  static Future<AuthRefresh> refreshAccessToken() => _refreshing ??= _refresh().whenComplete(() => _refreshing = null);
+
+  static Future<AuthRefresh> _refresh() async {
     final refreshToken = await getRefreshToken();
-    if (refreshToken == null) return null;
+    if (refreshToken == null) return const AuthRefresh.failed(AuthFailure.auth);
     try {
       final cfg = await OidcConfig.settings();
       final result = await _appAuth.token(
@@ -137,9 +181,9 @@ class AuthService {
         ),
       );
       final tokens = await _persist(result);
-      return tokens.accessToken;
-    } catch (_) {
-      return null;
+      return AuthRefresh.token(tokens.accessToken);
+    } catch (e) {
+      return AuthRefresh.failed(classifyRefreshError(e));
     }
   }
 
@@ -157,21 +201,41 @@ class AuthService {
     }
   }
 
-  static Future<void> signOut() async {
+  static Future<bool>? _signingOut;
+
+  /// Ends the session. [endSession] drives the provider's logout page in the
+  /// system browser; pass false for a silent local sign-out (an expired session
+  /// has nothing left to log out of). Memoised, because N requests failing at
+  /// once must not open N browser tabs. Returns true only for the call that
+  /// actually ended a live session, so exactly one caller reports it.
+  static Future<bool> signOut({bool endSession = true}) {
+    final pending = _signingOut;
+    if (pending != null) return pending.then((_) => false);
+    return _signingOut = _signOut(endSession: endSession).whenComplete(() => _signingOut = null);
+  }
+
+  static Future<bool> _signOut({required bool endSession}) async {
+    await _ensureMigrated();
     final idToken = await _storage.read(key: _kIdTokenKey);
-    try {
-      final cfg = await OidcConfig.settings();
-      if (cfg.endSessionEndpoint != null) {
-        await _appAuth.endSession(
-          EndSessionRequest(
-            idTokenHint: idToken,
-            postLogoutRedirectUrl: cfg.redirectUri,
-            serviceConfiguration: _serviceConfig(cfg),
-            allowInsecureConnections: cfg.allowInsecureConnections,
-          ),
-        );
+    final hadSession = idToken != null || _accessToken != null || await _storage.read(key: _kRefreshTokenKey) != null;
+    // No id token means there is no provider session to end - private mode, or
+    // one already dropped - and endSession would just strand the user on a
+    // logout page for an account they never signed into.
+    if (endSession && idToken != null) {
+      try {
+        final cfg = await OidcConfig.settings();
+        if (cfg.endSessionEndpoint != null) {
+          await _appAuth.endSession(
+            EndSessionRequest(
+              idTokenHint: idToken,
+              postLogoutRedirectUrl: cfg.redirectUri,
+              serviceConfiguration: _serviceConfig(cfg),
+              allowInsecureConnections: cfg.allowInsecureConnections,
+            ),
+          );
+        }
+      } catch (_) {
       }
-    } catch (_) {
     }
     _accessToken = null;
     _accessTokenExpiry = null;
@@ -183,5 +247,6 @@ class AuthService {
     await prefs.remove(_kIdTokenKey);
     await prefs.remove(_kRefreshTokenKey);
     sessionEpoch.value++;
+    return hadSession;
   }
 }

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -49,10 +49,14 @@ class _RootScreenState extends State<RootScreen> {
       return;
     }
     final token = await AuthService.getAccessToken();
-    if (token == null) {
+    // A refresh that failed on the network still leaves a usable session - the
+    // dashboard shows its own offline state. Only a session that is really gone
+    // drops the active school and goes back to the sign-in screen.
+    final signedIn = token != null || await AuthService.hasSession();
+    if (!signedIn) {
       await ActiveAccountService.instance.clear();
     }
-    if (mounted) setState(() => _ready = token != null);
+    if (mounted) setState(() => _ready = signedIn);
   }
 
   Future<void> _signIn({bool register = false}) async {

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -78,7 +78,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final svc = ActiveAccountService.instance;
     await svc.refresh();
     if (!mounted) return;
-    if (svc.schools.isEmpty) {
+    // Empty only counts when the server actually answered - a cold start with no
+    // network must not greet the user with the add-school flow.
+    if (svc.schools.isEmpty && svc.error == null) {
       await _addSchool();
     } else {
       _lastSchoolId = svc.active?.id;

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -213,9 +213,11 @@ class _ServerDialogState extends State<_ServerDialog> {
       setState(() => _busy = true);
     }
 
+    // Log out of the provider we are still pointed at - after the switch the
+    // end-session call would land on the new backend's provider.
+    await AuthService.signOut();
     await BackendConfig.setUrl(url);
     OidcConfig.reset();
-    await AuthService.signOut();
     await PrivateAccountStore.instance.clear();
     await ActiveAccountService.instance.clear();
     SchoolDataService.instance.clear();

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/services/auth_service.dart';
+
+FlutterAppAuthPlatformException _platformError(String? error) => FlutterAppAuthPlatformException(
+      code: 'token_failed',
+      platformErrorDetails: FlutterAppAuthPlatformErrorDetails(error: error),
+    );
+
+void main() {
+  group('AuthService.classifyRefreshError', () {
+    test('invalid_grant is an auth failure', () {
+      expect(AuthService.classifyRefreshError(_platformError('invalid_grant')), AuthFailure.auth);
+    });
+
+    test('invalid_client is an auth failure', () {
+      expect(AuthService.classifyRefreshError(_platformError('invalid_client')), AuthFailure.auth);
+    });
+
+    test('a non-OAuth platform error is a transport failure', () {
+      expect(AuthService.classifyRefreshError(_platformError('Network error')), AuthFailure.transport);
+    });
+
+    test('a platform error with no error code is a transport failure', () {
+      expect(AuthService.classifyRefreshError(_platformError(null)), AuthFailure.transport);
+    });
+
+    test('a plain exception is a transport failure', () {
+      expect(AuthService.classifyRefreshError(Exception('boom')), AuthFailure.transport);
+    });
+
+    test('a timeout is a transport failure', () {
+      expect(AuthService.classifyRefreshError(TimeoutException('timed out')), AuthFailure.transport);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Token refreshes now report why they failed: only an OAuth error from the provider (`invalid_grant` and the other standard codes) ends the session; a timeout, a DNS failure or a 5xx keeps the stored tokens and surfaces a retryable error instead.
- `signOut()` is memoised and takes `endSession`, so concurrent 401s can no longer open several provider logout tabs, and an expired session is dropped locally with `RootScreen` reacting to `sessionEpoch`.
- Exactly one "Session expired" toast per ended session, and the retried request no longer toasts its failure twice; a 401 on the retry now actually ends the session.
- A cold start with a stored refresh token but no network keeps the active school and shows the dashboard in its offline state instead of bouncing to the sign-in screen, and it no longer opens the add-school flow just because the school list could not be fetched.
- Changing the backend URL logs out of the provider the app is still pointed at, and private mode no longer opens a logout page for an account that was never signed into.
- Unit tests for the refresh-error classification.

Closes #476
Closes #479
Closes #484
