### PR TITLE
Guard concurrent school data refreshes and cache them for cold start

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import 'config/backend_config.dart';
 import 'l10n/app_localizations.dart';
 import 'services/app_mode_service.dart';
+import 'services/school_data_service.dart';
 import 'services/theme_service.dart';
 import 'services/toast_service.dart';
 import 'ui/core/ui/root_screen.dart';
@@ -13,6 +14,7 @@ Future<void> main() async {
   await BackendConfig.load();
   await AppModeService.instance.load();
   await ThemeService.instance.load();
+  await SchoolDataService.instance.loadCached();
   runApp(const SchulyApp());
 }
 

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -147,4 +147,9 @@ class ActiveAccountService extends ChangeNotifier {
     await prefs.remove(_activeIdKey);
     notifyListeners();
   }
+
+  static Future<String?> persistedActiveId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_activeIdKey);
+  }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -20,11 +20,13 @@ class AuthTokens {
 /// (Android) - the system browser, never a WebView, and never an in-app
 /// credential form. The client is public (no secret); PKCE (S256) replaces it.
 class AuthService {
-  // Only the refresh token and id token are persisted. The access token is kept
-  // in memory (per OAuth mobile best practice) and re-minted from the refresh
-  // token on cold start.
+  // The refresh token, id token, and access token (with its expiry) are all
+  // persisted in the keystore, so a cold start can skip the refresh round trip
+  // while the cached access token is still valid.
   static const _kRefreshTokenKey = 'auth.refresh_token';
   static const _kIdTokenKey = 'auth.id_token';
+  static const _kAccessTokenKey = 'auth.access_token.v2';
+  static const _kAccessTokenExpiryKey = 'auth.access_token_expiry';
   // Legacy key from the old hand-rolled flow that persisted the access token.
   static const _kLegacyAccessTokenKey = 'auth.access_token';
 
@@ -97,13 +99,36 @@ class AuthService {
     if (tokens.idToken != null) {
       await _storage.write(key: _kIdTokenKey, value: tokens.idToken!);
     }
+    await _storage.write(key: _kAccessTokenKey, value: tokens.accessToken);
+    if (tokens.accessTokenExpiry != null) {
+      await _storage.write(key: _kAccessTokenExpiryKey, value: tokens.accessTokenExpiry!.toIso8601String());
+    } else {
+      await _storage.delete(key: _kAccessTokenExpiryKey);
+    }
     return tokens;
+  }
+
+  static Future<void>? _restore;
+  static Future<void> _ensureRestored() => _restore ??= _restoreAccessToken();
+
+  static Future<void> _restoreAccessToken() async {
+    await _ensureMigrated();
+    final token = await _storage.read(key: _kAccessTokenKey);
+    final expiry = await _storage.read(key: _kAccessTokenExpiryKey);
+    if (token == null || expiry == null) return;
+    final parsed = DateTime.tryParse(expiry);
+    if (parsed == null) return;
+    if (_accessToken == null) {
+      _accessToken = token;
+      _accessTokenExpiry = parsed;
+    }
   }
 
   /// Returns a usable access token: the in-memory one if still valid, otherwise
   /// a freshly refreshed one. Null when there's no session (no refresh token or
   /// the refresh failed) - the caller should treat that as signed-out.
   static Future<String?> getAccessToken() async {
+    await _ensureRestored();
     final token = _accessToken;
     final expiry = _accessTokenExpiry;
     if (token != null && expiry != null && expiry.isAfter(DateTime.now().add(const Duration(seconds: 30)))) {
@@ -178,10 +203,13 @@ class AuthService {
     await _storage.delete(key: _kRefreshTokenKey);
     await _storage.delete(key: _kIdTokenKey);
     await _storage.delete(key: _kLegacyAccessTokenKey);
+    await _storage.delete(key: _kAccessTokenKey);
+    await _storage.delete(key: _kAccessTokenExpiryKey);
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_kLegacyAccessTokenKey);
     await prefs.remove(_kIdTokenKey);
     await prefs.remove(_kRefreshTokenKey);
+    _restore = null;
     sessionEpoch.value++;
   }
 }

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -1,4 +1,5 @@
 import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart' show Response;
 import 'package:flutter/foundation.dart';
 import 'package:schuly_api/schuly_api.dart';
 
@@ -7,12 +8,16 @@ import 'api_client.dart';
 import 'app_mode_service.dart';
 import 'private_account_store.dart';
 import 'private_data_adapter.dart';
+import 'school_data_snapshot.dart';
 import 'scrape_proxy_client.dart';
+import 'toast_service.dart';
 import 'token_proxy_client.dart';
 
 class SchoolDataService extends ChangeNotifier {
   SchoolDataService._();
   static final SchoolDataService instance = SchoolDataService._();
+
+  static const _handled = <String, dynamic>{ApiClient.handlesErrors: true};
 
   SchoolUserDto? _me;
   List<ExamDto> _exams = const [];
@@ -24,6 +29,9 @@ class SchoolDataService extends ChangeNotifier {
   List<StudentDocumentDto> _documents = const [];
   bool _loading = false;
   Object? _error;
+  int _generation = 0;
+  bool _hasLoaded = false;
+  String? _snapshotKey;
 
   SchoolUserDto? get me => _me;
   List<ExamDto> get exams => _exams;
@@ -35,6 +43,7 @@ class SchoolDataService extends ChangeNotifier {
   List<StudentDocumentDto> get documents => _documents;
   bool get loading => _loading;
   Object? get error => _error;
+  bool get hasLoaded => _hasLoaded;
 
   Map<String, String> get classNameById {
     final out = <String, String>{};
@@ -57,18 +66,58 @@ class SchoolDataService extends ChangeNotifier {
     return out;
   }
 
-  Future<void> refresh() async {
+  String? get _currentKey {
+    if (AppModeService.instance.isPrivate) return 'private';
+    final id = ActiveAccountService.instance.active?.id;
+    return id == null ? null : 'account.$id';
+  }
+
+  /// Loads the last successful snapshot from disk so the first frame shows real
+  /// data instead of an empty home. Called once at startup, before a live
+  /// [refresh] has had a chance to commit.
+  Future<void> loadCached() async {
+    if (_hasLoaded) return;
+    String? key;
     if (AppModeService.instance.isPrivate) {
-      await _refreshPrivate();
+      key = 'private';
+    } else {
+      final id = await ActiveAccountService.persistedActiveId();
+      if (id == null) return;
+      key = 'account.$id';
+    }
+
+    final gen = _generation;
+    final snapshot = await SchoolDataSnapshotStore.instance.load(key);
+    if (snapshot == null || gen != _generation || _hasLoaded) return;
+
+    _me = snapshot.me;
+    _exams = snapshot.exams;
+    _agenda = snapshot.agenda;
+    _absences = snapshot.absences;
+    _classes = snapshot.classes;
+    _reports = snapshot.reports;
+    _teachers = snapshot.teachers;
+    _documents = snapshot.documents;
+    _snapshotKey = key;
+    _hasLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> refresh() async {
+    final gen = ++_generation;
+    final key = _currentKey;
+    if (_snapshotKey != null && _snapshotKey != key) _resetData();
+    _snapshotKey = key;
+
+    if (AppModeService.instance.isPrivate) {
+      await _refreshPrivate(gen);
       return;
     }
 
     final schoolId = ActiveAccountService.instance.active?.id;
     if (schoolId == null) {
-      _me = null;
-      _exams = const [];
-      _agenda = const [];
-      _absences = const [];
+      _resetData();
+      _hasLoaded = true;
       notifyListeners();
       return;
     }
@@ -77,29 +126,39 @@ class SchoolDataService extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
-      final me = await _api.getAuthApi().apiAuthMeGet();
+      final me = await _api.getAuthApi().apiAuthMeGet(extra: _handled);
       final appUserId = me.data?.id;
+      SchoolUserDto? mine;
       if (appUserId != null) {
         final users = await _api
             .getSchoolUsersApi()
-            .apiSchoolUsersGet(applicationUserId: appUserId);
-        _me = (users.data ?? BuiltList<SchoolUserDto>())
+            .apiSchoolUsersGet(applicationUserId: appUserId, extra: _handled);
+        mine = (users.data ?? BuiltList<SchoolUserDto>())
             .where((u) => u.schoolId == schoolId)
             .cast<SchoolUserDto?>()
             .firstWhere((_) => true, orElse: () => null);
       }
 
-      final exams = await _api.getExamsApi().apiExamsGet();
-      _exams = (exams.data ?? BuiltList<ExamDto>())
+      final myClassIds = {
+        for (final c in (mine?.classes ?? const <UserClassDto>[])) c.classId,
+      };
+      final meId = mine?.id;
+
+      final responses = await Future.wait<Response<dynamic>>([
+        _api.getExamsApi().apiExamsGet(extra: _handled),
+        _api.getAgendasApi().apiAgendasGet(extra: _handled),
+        _api.getAbsencesApi().apiAbsencesGet(extra: _handled),
+        _api.getClassApi().apiClassGet(extra: _handled),
+        _api.getSemesterReportsApi().apiSemesterReportsGet(extra: _handled),
+        _api.getTeachersApi().apiTeachersGet(extra: _handled),
+        _api.getStudentDocumentsApi().apiDocumentsGet(extra: _handled),
+      ]);
+
+      final exams = ((responses[0].data as BuiltList<ExamDto>?) ?? BuiltList<ExamDto>())
           .where((e) => e.schoolId == schoolId)
           .toList(growable: false);
 
-      final myClassIds = {
-        for (final c in (_me?.classes ?? const <UserClassDto>[])) c.classId,
-      };
-      final meId = _me?.id;
-      final agenda = await _api.getAgendasApi().apiAgendasGet();
-      _agenda = (agenda.data ?? BuiltList<AgendaEntryDto>())
+      final agenda = ((responses[1].data as BuiltList<AgendaEntryDto>?) ?? BuiltList<AgendaEntryDto>())
           .where((a) =>
               (meId != null && a.schoolUserId == meId) ||
               a.entryType == AgendaEntryType.holiday ||
@@ -107,42 +166,60 @@ class SchoolDataService extends ChangeNotifier {
               myClassIds.contains(a.classId))
           .toList(growable: false);
 
-      final absences = await _api.getAbsencesApi().apiAbsencesGet();
-      _absences = (absences.data ?? BuiltList<AbsenceDto>())
+      final absences = ((responses[2].data as BuiltList<AbsenceDto>?) ?? BuiltList<AbsenceDto>())
           .where((a) => a.schoolId == schoolId)
           .toList(growable: false);
 
-      final classes = await _api.getClassApi().apiClassGet();
-      _classes = (classes.data ?? BuiltList<ClassDto>())
+      final classes = ((responses[3].data as BuiltList<ClassDto>?) ?? BuiltList<ClassDto>())
           .where((c) => c.schoolId == schoolId)
           .toList(growable: false);
 
-      final reports = await _api.getSemesterReportsApi().apiSemesterReportsGet();
-      _reports = (reports.data ?? BuiltList<SemesterReportDto>())
+      final reports = ((responses[4].data as BuiltList<SemesterReportDto>?) ?? BuiltList<SemesterReportDto>())
           .where((r) => meId == null || r.schoolUserId == meId)
           .toList(growable: false);
 
-      final teachers = await _api.getTeachersApi().apiTeachersGet();
-      _teachers = (teachers.data ?? BuiltList<TeacherDto>())
+      final teachers = ((responses[5].data as BuiltList<TeacherDto>?) ?? BuiltList<TeacherDto>())
           .where((t) => t.schoolId == schoolId)
           .toList(growable: false);
 
-      final documents = await _api.getStudentDocumentsApi().apiDocumentsGet();
-      _documents = (documents.data ?? BuiltList<StudentDocumentDto>())
+      final documents = ((responses[6].data as BuiltList<StudentDocumentDto>?) ?? BuiltList<StudentDocumentDto>())
           .where((d) => meId == null || d.schoolUserId == meId)
           .toList(growable: false);
+
+      if (gen != _generation) return;
+      _me = mine;
+      _exams = exams;
+      _agenda = agenda;
+      _absences = absences;
+      _classes = classes;
+      _reports = reports;
+      _teachers = teachers;
+      _documents = documents;
+      if (key != null) {
+        await SchoolDataSnapshotStore.instance.save(
+            key,
+            SchoolDataSnapshot(me: _me, exams: _exams, agenda: _agenda, absences: _absences, classes: _classes, reports: _reports, teachers: _teachers, documents: _documents));
+      }
+      _hasLoaded = true;
     } catch (e) {
+      if (gen != _generation) return;
       _error = e;
+      if (_me != null) ToastService.error('Could not refresh', e);
     } finally {
-      _loading = false;
-      notifyListeners();
+      if (gen == _generation) {
+        _loading = false;
+        notifyListeners();
+      }
     }
   }
 
-  Future<void> _refreshPrivate() async {
+  Future<void> _refreshPrivate(int gen) async {
     final account = await PrivateAccountStore.instance.load();
     if (account == null) {
-      clear();
+      _resetData();
+      _hasLoaded = true;
+      _snapshotKey = null;
+      notifyListeners();
       return;
     }
 
@@ -150,36 +227,56 @@ class SchoolDataService extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
+      SchoolUserDto? mine;
+      List<ExamDto> exams;
+      List<AbsenceDto> absences;
+      List<AgendaEntryDto> agenda;
+      List<ClassDto> classes;
       if (account.accessToken != null) {
         final d = await TokenProxyClient.instance.fetchAll(account);
         if (d.refreshedAccount != null) {
           await PrivateAccountStore.instance.save(d.refreshedAccount!);
         }
-        _me = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, d.absences);
-        _exams = PrivateDataAdapter.exams(d.exams);
-        _absences = PrivateDataAdapter.absencesList(d.absences);
-        _agenda = PrivateDataAdapter.agenda(d.agenda);
-        _classes = PrivateDataAdapter.classes(d.grades, d.exams);
+        mine = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, d.absences);
+        exams = PrivateDataAdapter.exams(d.exams);
+        absences = PrivateDataAdapter.absencesList(d.absences);
+        agenda = PrivateDataAdapter.agenda(d.agenda);
+        classes = PrivateDataAdapter.classes(d.grades, d.exams);
       } else {
         final d = await ScrapeProxyClient.instance.data(account);
-        _me = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, const []);
-        _exams = PrivateDataAdapter.exams(d.exams);
-        _absences = const [];
-        _agenda = PrivateDataAdapter.agenda(d.agenda);
-        _classes = PrivateDataAdapter.classes(d.grades, d.exams);
+        mine = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, const []);
+        exams = PrivateDataAdapter.exams(d.exams);
+        absences = const [];
+        agenda = PrivateDataAdapter.agenda(d.agenda);
+        classes = PrivateDataAdapter.classes(d.grades, d.exams);
       }
+
+      if (gen != _generation) return;
+      _me = mine;
+      _exams = exams;
+      _absences = absences;
+      _agenda = agenda;
+      _classes = classes;
       _reports = const [];
       _teachers = const [];
       _documents = const [];
+      await SchoolDataSnapshotStore.instance.save(
+          'private',
+          SchoolDataSnapshot(me: _me, exams: _exams, agenda: _agenda, absences: _absences, classes: _classes, reports: _reports, teachers: _teachers, documents: _documents));
+      _hasLoaded = true;
     } catch (e) {
+      if (gen != _generation) return;
       _error = e;
+      if (_me != null) ToastService.error('Could not refresh', e);
     } finally {
-      _loading = false;
-      notifyListeners();
+      if (gen == _generation) {
+        _loading = false;
+        notifyListeners();
+      }
     }
   }
 
-  void clear() {
+  void _resetData() {
     _me = null;
     _exams = const [];
     _agenda = const [];
@@ -189,6 +286,25 @@ class SchoolDataService extends ChangeNotifier {
     _teachers = const [];
     _documents = const [];
     _error = null;
+    _hasLoaded = false;
+  }
+
+  void clear() {
+    _generation++;
+    _resetData();
+    _snapshotKey = null;
     notifyListeners();
+  }
+
+  /// Ends the first-load state without touching the data: the school list could
+  /// not be fetched, so the cached snapshot is the best there is to show.
+  void settle() {
+    if (_hasLoaded) return;
+    _hasLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> clearCache() async {
+    await SchoolDataSnapshotStore.instance.clear();
   }
 }

--- a/lib/services/school_data_snapshot.dart
+++ b/lib/services/school_data_snapshot.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:built_value/serializer.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+class SchoolDataSnapshot {
+  final SchoolUserDto? me;
+  final List<ExamDto> exams;
+  final List<AgendaEntryDto> agenda;
+  final List<AbsenceDto> absences;
+  final List<ClassDto> classes;
+  final List<SemesterReportDto> reports;
+  final List<TeacherDto> teachers;
+  final List<StudentDocumentDto> documents;
+
+  const SchoolDataSnapshot({required this.me, required this.exams, required this.agenda, required this.absences, required this.classes, required this.reports, required this.teachers, required this.documents});
+
+  Map<String, dynamic> toJson() => {
+        'version': 1,
+        'me': me == null ? null : standardSerializers.serializeWith(SchoolUserDto.serializer, me!),
+        'exams': _encode(exams, ExamDto.serializer),
+        'agenda': _encode(agenda, AgendaEntryDto.serializer),
+        'absences': _encode(absences, AbsenceDto.serializer),
+        'classes': _encode(classes, ClassDto.serializer),
+        'reports': _encode(reports, SemesterReportDto.serializer),
+        'teachers': _encode(teachers, TeacherDto.serializer),
+        'documents': _encode(documents, StudentDocumentDto.serializer),
+      };
+
+  static SchoolDataSnapshot? fromJson(Map<String, dynamic> json) {
+    if (json['version'] != 1) return null;
+    try {
+      final rawMe = json['me'] as Map<String, dynamic>?;
+      return SchoolDataSnapshot(
+        me: rawMe == null ? null : standardSerializers.deserializeWith(SchoolUserDto.serializer, rawMe),
+        exams: _list(json['exams'], ExamDto.serializer),
+        agenda: _list(json['agenda'], AgendaEntryDto.serializer),
+        absences: _list(json['absences'], AbsenceDto.serializer),
+        classes: _list(json['classes'], ClassDto.serializer),
+        reports: _list(json['reports'], SemesterReportDto.serializer),
+        teachers: _list(json['teachers'], TeacherDto.serializer),
+        documents: _list(json['documents'], StudentDocumentDto.serializer),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static List<Object?> _encode<T>(List<T> items, Serializer<T> serializer) => items.map((item) => standardSerializers.serializeWith(serializer, item)).toList(growable: false);
+
+  static List<T> _list<T>(Object? raw, Serializer<T> serializer) => (raw as List<dynamic>).map((item) => standardSerializers.deserializeWith(serializer, item as Map<String, dynamic>)!).toList(growable: false);
+}
+
+class SchoolDataSnapshotStore {
+  SchoolDataSnapshotStore._();
+  static final SchoolDataSnapshotStore instance = SchoolDataSnapshotStore._();
+
+  Future<Directory> _dir() async {
+    final support = await getApplicationSupportDirectory();
+    return Directory('${support.path}/school_data');
+  }
+
+  File _fileFor(Directory dir, String key) {
+    final sanitised = key.replaceAll(RegExp(r'[^A-Za-z0-9_.-]'), '_');
+    return File('${dir.path}/$sanitised.json');
+  }
+
+  Future<SchoolDataSnapshot?> load(String key) async {
+    try {
+      final file = _fileFor(await _dir(), key);
+      final raw = await file.readAsString();
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return SchoolDataSnapshot.fromJson(json);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> save(String key, SchoolDataSnapshot snapshot) async {
+    try {
+      final dir = await _dir();
+      await dir.create(recursive: true);
+      final file = _fileFor(dir, key);
+      await file.writeAsString(jsonEncode(snapshot.toJson()));
+    } catch (_) {}
+  }
+
+  Future<void> clear() async {
+    try {
+      final dir = await _dir();
+      if (await dir.exists()) await dir.delete(recursive: true);
+    } catch (_) {}
+  }
+}

--- a/lib/services/school_data_snapshot.dart
+++ b/lib/services/school_data_snapshot.dart
@@ -18,40 +18,86 @@ class SchoolDataSnapshot {
 
   const SchoolDataSnapshot({required this.me, required this.exams, required this.agenda, required this.absences, required this.classes, required this.reports, required this.teachers, required this.documents});
 
-  Map<String, dynamic> toJson() => {
+  /// Builds the disk representation. A single unserialisable exam, grade, etc.
+  /// must never blank the whole cache: each section (and [me]) is encoded
+  /// independently, so one bad item is dropped (and logged) instead of taking
+  /// the rest of the snapshot down with it. (Non-finite doubles such as
+  /// `classAverage` are not a risk here: built_value's own [DoubleSerializer]
+  /// already turns `NaN`/`Infinity` into the sentinel strings `'NaN'`/`'INF'`
+  /// before `jsonEncode` ever sees a raw double, and reverses that on decode.)
+  Map<String, dynamic> toJson() => <String, dynamic>{
         'version': 1,
-        'me': me == null ? null : standardSerializers.serializeWith(SchoolUserDto.serializer, me!),
-        'exams': _encode(exams, ExamDto.serializer),
-        'agenda': _encode(agenda, AgendaEntryDto.serializer),
-        'absences': _encode(absences, AbsenceDto.serializer),
-        'classes': _encode(classes, ClassDto.serializer),
-        'reports': _encode(reports, SemesterReportDto.serializer),
-        'teachers': _encode(teachers, TeacherDto.serializer),
-        'documents': _encode(documents, StudentDocumentDto.serializer),
+        'me': me == null ? null : _encodeOne(me!, SchoolUserDto.serializer, 'me'),
+        'exams': _encode(exams, ExamDto.serializer, 'exams'),
+        'agenda': _encode(agenda, AgendaEntryDto.serializer, 'agenda'),
+        'absences': _encode(absences, AbsenceDto.serializer, 'absences'),
+        'classes': _encode(classes, ClassDto.serializer, 'classes'),
+        'reports': _encode(reports, SemesterReportDto.serializer, 'reports'),
+        'teachers': _encode(teachers, TeacherDto.serializer, 'teachers'),
+        'documents': _encode(documents, StudentDocumentDto.serializer, 'documents'),
       };
 
   static SchoolDataSnapshot? fromJson(Map<String, dynamic> json) {
     if (json['version'] != 1) return null;
     try {
       final rawMe = json['me'] as Map<String, dynamic>?;
+      SchoolUserDto? me;
+      if (rawMe != null) {
+        try {
+          me = standardSerializers.deserializeWith(SchoolUserDto.serializer, rawMe);
+        } catch (e, st) {
+          debugPrint('SchoolDataSnapshot.fromJson: failed to decode me, dropping: $e\n$st');
+        }
+      }
       return SchoolDataSnapshot(
-        me: rawMe == null ? null : standardSerializers.deserializeWith(SchoolUserDto.serializer, rawMe),
-        exams: _list(json['exams'], ExamDto.serializer),
-        agenda: _list(json['agenda'], AgendaEntryDto.serializer),
-        absences: _list(json['absences'], AbsenceDto.serializer),
-        classes: _list(json['classes'], ClassDto.serializer),
-        reports: _list(json['reports'], SemesterReportDto.serializer),
-        teachers: _list(json['teachers'], TeacherDto.serializer),
-        documents: _list(json['documents'], StudentDocumentDto.serializer),
+        me: me,
+        exams: _list(json['exams'], ExamDto.serializer, 'exams'),
+        agenda: _list(json['agenda'], AgendaEntryDto.serializer, 'agenda'),
+        absences: _list(json['absences'], AbsenceDto.serializer, 'absences'),
+        classes: _list(json['classes'], ClassDto.serializer, 'classes'),
+        reports: _list(json['reports'], SemesterReportDto.serializer, 'reports'),
+        teachers: _list(json['teachers'], TeacherDto.serializer, 'teachers'),
+        documents: _list(json['documents'], StudentDocumentDto.serializer, 'documents'),
       );
-    } catch (_) {
+    } catch (e, st) {
+      debugPrint('SchoolDataSnapshot.fromJson: malformed snapshot, discarding: $e\n$st');
       return null;
     }
   }
 
-  static List<Object?> _encode<T>(List<T> items, Serializer<T> serializer) => items.map((item) => standardSerializers.serializeWith(serializer, item)).toList(growable: false);
+  static Object? _encodeOne<T>(T item, Serializer<T> serializer, String label) {
+    try {
+      return standardSerializers.serializeWith(serializer, item);
+    } catch (e, st) {
+      debugPrint('SchoolDataSnapshot.toJson: failed to encode $label, dropping: $e\n$st');
+      return null;
+    }
+  }
 
-  static List<T> _list<T>(Object? raw, Serializer<T> serializer) => (raw as List<dynamic>).map((item) => standardSerializers.deserializeWith(serializer, item as Map<String, dynamic>)!).toList(growable: false);
+  static List<Object?> _encode<T>(List<T> items, Serializer<T> serializer, String label) {
+    final out = <Object?>[];
+    for (final item in items) {
+      try {
+        out.add(standardSerializers.serializeWith(serializer, item));
+      } catch (e, st) {
+        debugPrint('SchoolDataSnapshot.toJson: failed to encode a $label item, skipping: $e\n$st');
+      }
+    }
+    return out;
+  }
+
+  static List<T> _list<T>(Object? raw, Serializer<T> serializer, String label) {
+    final out = <T>[];
+    for (final item in raw as List<dynamic>) {
+      try {
+        final decoded = standardSerializers.deserializeWith(serializer, item as Map<String, dynamic>);
+        if (decoded != null) out.add(decoded);
+      } catch (e, st) {
+        debugPrint('SchoolDataSnapshot.fromJson: failed to decode a $label item, skipping: $e\n$st');
+      }
+    }
+    return out;
+  }
 }
 
 class SchoolDataSnapshotStore {

--- a/lib/services/school_data_snapshot.dart
+++ b/lib/services/school_data_snapshot.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:built_value/serializer.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:schuly_api/schuly_api.dart';
 
@@ -73,7 +74,8 @@ class SchoolDataSnapshotStore {
       final raw = await file.readAsString();
       final json = jsonDecode(raw) as Map<String, dynamic>;
       return SchoolDataSnapshot.fromJson(json);
-    } catch (_) {
+    } catch (e, st) {
+      debugPrint('SchoolDataSnapshotStore.load failed for "$key": $e\n$st');
       return null;
     }
   }
@@ -84,7 +86,9 @@ class SchoolDataSnapshotStore {
       await dir.create(recursive: true);
       final file = _fileFor(dir, key);
       await file.writeAsString(jsonEncode(snapshot.toJson()));
-    } catch (_) {}
+    } catch (e, st) {
+      debugPrint('SchoolDataSnapshotStore.save failed for "$key": $e\n$st');
+    }
   }
 
   Future<void> clear() async {

--- a/lib/services/school_data_snapshot.dart
+++ b/lib/services/school_data_snapshot.dart
@@ -6,6 +6,34 @@ import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:schuly_api/schuly_api.dart';
 
+/// Snapshot-only stand-in for the generated client's `Iso8601DateTimeSerializer`.
+/// DTOs reach [SchoolDataSnapshot] with local `DateTime`s (converted by
+/// `ApiTime` before they enter [SchoolDataService]), but the generated
+/// serializer throws on anything that isn't UTC. This accepts either kind,
+/// always writing UTC on the wire and decoding back to UTC - the same kind
+/// the generated deserializer produces - so cached and freshly-fetched values
+/// agree before `ApiTime` runs over them.
+class _SnapshotDateTimeSerializer implements PrimitiveSerializer<DateTime> {
+  const _SnapshotDateTimeSerializer();
+
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = const [DateTime];
+  @override
+  final String wireName = 'DateTime';
+
+  @override
+  Object serialize(Serializers serializers, DateTime dateTime, {FullType specifiedType = FullType.unspecified}) => dateTime.toUtc().toIso8601String();
+
+  @override
+  DateTime deserialize(Serializers serializers, Object? serialized, {FullType specifiedType = FullType.unspecified}) => DateTime.parse(serialized as String).toUtc();
+}
+
+/// Codec used for the disk snapshot only. Built from [standardSerializers]
+/// (keeping [StandardJsonPlugin]) with the DateTime serializer swapped for
+/// [_SnapshotDateTimeSerializer].
+final Serializers _snapshotSerializers = (standardSerializers.toBuilder()..add(const _SnapshotDateTimeSerializer())).build();
+
 class SchoolDataSnapshot {
   final SchoolUserDto? me;
   final List<ExamDto> exams;
@@ -44,7 +72,7 @@ class SchoolDataSnapshot {
       SchoolUserDto? me;
       if (rawMe != null) {
         try {
-          me = standardSerializers.deserializeWith(SchoolUserDto.serializer, rawMe);
+          me = _snapshotSerializers.deserializeWith(SchoolUserDto.serializer, rawMe);
         } catch (e, st) {
           debugPrint('SchoolDataSnapshot.fromJson: failed to decode me, dropping: $e\n$st');
         }
@@ -67,7 +95,7 @@ class SchoolDataSnapshot {
 
   static Object? _encodeOne<T>(T item, Serializer<T> serializer, String label) {
     try {
-      return standardSerializers.serializeWith(serializer, item);
+      return _snapshotSerializers.serializeWith(serializer, item);
     } catch (e, st) {
       debugPrint('SchoolDataSnapshot.toJson: failed to encode $label, dropping: $e\n$st');
       return null;
@@ -78,7 +106,7 @@ class SchoolDataSnapshot {
     final out = <Object?>[];
     for (final item in items) {
       try {
-        out.add(standardSerializers.serializeWith(serializer, item));
+        out.add(_snapshotSerializers.serializeWith(serializer, item));
       } catch (e, st) {
         debugPrint('SchoolDataSnapshot.toJson: failed to encode a $label item, skipping: $e\n$st');
       }
@@ -90,7 +118,7 @@ class SchoolDataSnapshot {
     final out = <T>[];
     for (final item in raw as List<dynamic>) {
       try {
-        final decoded = standardSerializers.deserializeWith(serializer, item as Map<String, dynamic>);
+        final decoded = _snapshotSerializers.deserializeWith(serializer, item as Map<String, dynamic>);
         if (decoded != null) out.add(decoded);
       } catch (e, st) {
         debugPrint('SchoolDataSnapshot.fromJson: failed to decode a $label item, skipping: $e\n$st');

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -7,6 +7,7 @@ import '../../../services/app_mode_service.dart';
 import '../../../services/auth_service.dart';
 import '../../../services/onboarding_service.dart';
 import '../../../services/private_account_store.dart';
+import '../../../services/school_data_service.dart';
 import '../../dashboard/dashboard_screen.dart';
 import '../../onboarding/onboarding_screen.dart';
 import '../../private/private_connect_flow.dart';
@@ -45,12 +46,14 @@ class _RootScreenState extends State<RootScreen> {
   Future<void> _refresh() async {
     if (AppModeService.instance.isPrivate) {
       final account = await PrivateAccountStore.instance.load();
+      if (account == null) SchoolDataService.instance.clear();
       if (mounted) setState(() => _ready = account != null);
       return;
     }
     final token = await AuthService.getAccessToken();
     if (token == null) {
       await ActiveAccountService.instance.clear();
+      SchoolDataService.instance.clear();
     }
     if (mounted) setState(() => _ready = token != null);
   }
@@ -97,6 +100,8 @@ class _RootScreenState extends State<RootScreen> {
       await AuthService.signOut();
       await ActiveAccountService.instance.clear();
     }
+    SchoolDataService.instance.clear();
+    await SchoolDataService.instance.clearCache();
     await _refresh();
   }
 

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -48,7 +48,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final id = ActiveAccountService.instance.active?.id;
     if (id != _lastSchoolId) {
       _lastSchoolId = id;
-      SchoolDataService.instance.clear();
       SchoolDataService.instance.refresh();
     }
   }
@@ -79,10 +78,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
     await svc.refresh();
     if (!mounted) return;
     if (svc.schools.isEmpty) {
-      await _addSchool();
-    } else {
-      _lastSchoolId = svc.active?.id;
+      if (svc.error != null) {
+        SchoolDataService.instance.settle();
+        return;
+      }
       await SchoolDataService.instance.refresh();
+      await _addSchool();
     }
   }
 
@@ -132,19 +133,33 @@ class _DashboardScreenState extends State<DashboardScreen> {
           ),
         ];
 
-        Widget body;
-        if (data.loading && data.me == null) {
-          body = const Center(child: FCircularProgress());
-        } else if (data.error != null && data.me == null) {
-          body = Center(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: SelectableText('Failed to load: ${data.error}',
-                  style: TextStyle(color: colors.destructive)),
+        Widget body = IndexedStack(index: _index, children: pages);
+        if (data.error != null && data.me == null) {
+          body = Stack(children: [
+            body,
+            Positioned.fill(
+              child: ColoredBox(
+                color: colors.background,
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: SelectableText('Failed to load: ${data.error}',
+                        style: TextStyle(color: colors.destructive)),
+                  ),
+                ),
+              ),
             ),
-          );
-        } else {
-          body = IndexedStack(index: _index, children: pages);
+          ]);
+        } else if (!data.hasLoaded) {
+          body = Stack(children: [
+            body,
+            Positioned.fill(
+              child: ColoredBox(
+                color: colors.background,
+                child: const Center(child: FCircularProgress()),
+              ),
+            ),
+          ]);
         }
 
         return FScaffold(

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import '../../../domain/my_school.dart';
 import '../../../services/active_account_service.dart';
 import '../../../services/app_mode_service.dart';
+import '../../../services/school_data_service.dart';
 import '../../authenticator/authenticator_vault_screen.dart';
 import '../../settings/settings_screen.dart';
 import 'add_school_modal.dart';
@@ -46,6 +47,7 @@ class AccountsSidebar extends StatelessWidget {
     if (confirmed != true) return;
     try {
       await ActiveAccountService.instance.removeSchool(school);
+      await SchoolDataService.instance.clearCache();
     } catch (_) {/* keep the sheet open; list reflects whatever succeeded */}
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
     source: hosted
     version: "5.1.1"
   built_value:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: built_value
       sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.9.2
   built_collection: ^5.1.1
+  built_value: ^8.4.0
   schuly_api:
     path: lib/api
   flutter_localizations:

--- a/test/school_data_service_test.dart
+++ b/test/school_data_service_test.dart
@@ -194,6 +194,57 @@ void main() {
       expect(restored.documents.single.notifiedAt, DateTime.utc(2026, 4, 1));
     });
 
+    test('accepts local DateTimes and preserves the instant', () {
+      // ApiTime converts DTO DateTimes to local time before they reach the
+      // cache (see lib/services/api_time.dart), so the snapshot codec must
+      // not throw on non-UTC values like the generated Iso8601DateTimeSerializer
+      // does.
+      final now = DateTime.now().toLocal();
+      final later = now.add(const Duration(hours: 1));
+
+      final agenda = [
+        AgendaEntryDto((b) => b
+          ..id = 'ag-1'
+          ..entryType = AgendaEntryType.lesson
+          ..title = 'Math'
+          ..date = now
+          ..endDate = later),
+      ];
+
+      final absences = [
+        AbsenceDto((b) => b
+          ..id = 'a-1'
+          ..reason = 'Sick'
+          ..type = AbsenceType.absence
+          ..from = now
+          ..until = later
+          ..schoolUserId = 'su-1'
+          ..schoolId = 's-1'),
+      ];
+
+      final documents = [
+        StudentDocumentDto((b) => b
+          ..id = 'd-1'
+          ..schoolUserId = 'su-1'
+          ..title = 'Report'
+          ..notifiedAt = now
+          ..createdAt = later),
+      ];
+
+      final snapshot = SchoolDataSnapshot(me: null, exams: const [], agenda: agenda, absences: absences, classes: const [], reports: const [], teachers: const [], documents: documents);
+
+      final encoded = jsonEncode(snapshot.toJson());
+      final restored = SchoolDataSnapshot.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
+
+      expect(restored, isNotNull);
+      expect(restored!.agenda.single.date.millisecondsSinceEpoch, now.millisecondsSinceEpoch);
+      expect(restored.agenda.single.endDate?.millisecondsSinceEpoch, later.millisecondsSinceEpoch);
+      expect(restored.absences.single.from.millisecondsSinceEpoch, now.millisecondsSinceEpoch);
+      expect(restored.absences.single.until.millisecondsSinceEpoch, later.millisecondsSinceEpoch);
+      expect(restored.documents.single.notifiedAt?.millisecondsSinceEpoch, now.millisecondsSinceEpoch);
+      expect(restored.documents.single.createdAt?.millisecondsSinceEpoch, later.millisecondsSinceEpoch);
+    });
+
     test('non-finite doubles do not break jsonEncode and round-trip intact', () {
       // built_value's DoubleSerializer turns NaN/Infinity into sentinel
       // strings ('NaN' / 'INF' / '-INF') before jsonEncode ever sees a raw

--- a/test/school_data_service_test.dart
+++ b/test/school_data_service_test.dart
@@ -14,14 +14,43 @@ void main() {
         ..email = 'ada@example.com'
         ..id = 'su-1'
         ..schoolId = 's-1'
-        ..role = Roles.student);
+        ..schoolName = 'School'
+        ..applicationUserId = 'au-1'
+        ..street = 'Main St'
+        ..city = 'City'
+        ..zip = '1234'
+        ..birthday = Date(2000, 1, 1)
+        ..entryDate = Date(2015, 9, 1)
+        ..role = Roles.student
+        ..state = UserState.active
+        ..createdAt = DateTime.utc(2024, 1, 1)
+        ..updatedAt = DateTime.utc(2024, 1, 2)
+        ..absences.add(AbsenceDto((a) => a
+          ..id = 'a-me'
+          ..reason = 'Sick'
+          ..type = AbsenceType.delay
+          ..from = DateTime.utc(2026, 1, 5)
+          ..until = DateTime.utc(2026, 1, 6)
+          ..schoolUserId = 'su-1'))
+        ..grades.add(GradeDto((g) => g
+          ..id = 'g-1'
+          ..score = 5.5
+          ..weighting = 1
+          ..examId = 'e-1'
+          ..schoolUserId = 'su-1'))
+        ..classes.add(UserClassDto((c) => c
+          ..classId = 'c-1'
+          ..className = '4a')));
 
       final exams = [
         ExamDto((b) => b
           ..id = 'e-1'
           ..name = 'Midterm'
+          ..description = 'Chapters 1-4'
+          ..type = ExamType.classic
           ..classAverage = 4.5
           ..date = Date(2026, 3, 12)
+          ..classId = 'c-1'
           ..schoolId = 's-1'
           ..grades.add(GradeDto((g) => g
             ..id = 'g-1'
@@ -32,8 +61,38 @@ void main() {
         ExamDto((b) => b
           ..id = 'e-2'
           ..name = 'Final'
-          ..classAverage = 4.0
+          ..type = ExamType.finalExam
+          ..classAverage = 0
           ..schoolId = 's-1'),
+      ];
+
+      final agenda = [
+        AgendaEntryDto((b) => b
+          ..id = 'ag-1'
+          ..entryType = AgendaEntryType.lesson
+          ..title = 'Math'
+          ..description = 'Algebra'
+          ..place = 'Room 1'
+          ..date = DateTime.utc(2026, 3, 1, 8)
+          ..endDate = DateTime.utc(2026, 3, 1, 9)
+          ..classId = 'c-1'
+          ..schoolId = 's-1'
+          ..schoolUserId = 'su-1'),
+        AgendaEntryDto((b) => b
+          ..id = 'ag-2'
+          ..entryType = AgendaEntryType.holiday
+          ..title = 'Holiday'
+          ..date = DateTime.utc(2026, 4, 1)),
+        AgendaEntryDto((b) => b
+          ..id = 'ag-3'
+          ..entryType = AgendaEntryType.test
+          ..title = 'Quiz'
+          ..date = DateTime.utc(2026, 3, 5)),
+        AgendaEntryDto((b) => b
+          ..id = 'ag-4'
+          ..entryType = AgendaEntryType.event
+          ..title = 'Event'
+          ..date = DateTime.utc(2026, 3, 6)),
       ];
 
       final absences = [
@@ -51,24 +110,139 @@ void main() {
         ClassDto((b) => b
           ..id = 'c-1'
           ..name = '4a'
-          ..schoolId = 's-1'),
+          ..description = 'Fourth grade A'
+          ..schoolId = 's-1'
+          ..schoolName = 'School'),
       ];
 
-      final snapshot = SchoolDataSnapshot(me: me, exams: exams, agenda: const [], absences: absences, classes: classes, reports: const [], teachers: const [], documents: const []);
+      final reports = [
+        SemesterReportDto((b) => b
+          ..id = 'r-1'
+          ..schoolUserId = 'su-1'
+          ..programCode = 'PC'
+          ..schoolYearStart = 2025
+          ..semesterHalf = 1
+          ..className = '4a'
+          ..promotionDecision = 'Promoted'
+          ..gradeAverage = 5.2
+          ..insufficientGradeCount = 0
+          ..deficiencyPoints = 0
+          ..excusedAbsences = 1
+          ..unexcusedAbsences = 0
+          ..totalAbsences = 1
+          ..subjects.add(SemesterSubjectGradeDto((s) => s
+            ..subjectCode = 'MATH'
+            ..subjectName = 'Math'
+            ..grade = 5.0))),
+      ];
 
-      final roundTripped = jsonDecode(jsonEncode(snapshot.toJson())) as Map<String, dynamic>;
+      final teachers = [
+        TeacherDto((b) => b
+          ..id = 't-1'
+          ..schoolId = 's-1'
+          ..schoolName = 'School'
+          ..firstName = 'John'
+          ..lastName = 'Doe'
+          ..code = 'JD'
+          ..email = 'jd@example.com'),
+      ];
+
+      final documents = [
+        StudentDocumentDto((b) => b
+          ..id = 'd-1'
+          ..schoolUserId = 'su-1'
+          ..title = 'Report'
+          ..comment = 'A comment'
+          ..category = 'General'
+          ..enteredBy = 'teacher'
+          ..fileName = 'file.pdf'
+          ..fileSizeBytes = 1234
+          ..followUpAction = 'Follow up'
+          ..followUpDate = Date(2026, 5, 1)
+          ..completedDate = Date(2026, 5, 2)
+          ..notifiedAt = DateTime.utc(2026, 4, 1)
+          ..createdAt = DateTime.utc(2026, 3, 1)),
+      ];
+
+      final snapshot = SchoolDataSnapshot(me: me, exams: exams, agenda: agenda, absences: absences, classes: classes, reports: reports, teachers: teachers, documents: documents);
+
+      final encoded = jsonEncode(snapshot.toJson());
+      final roundTripped = jsonDecode(encoded) as Map<String, dynamic>;
       final restored = SchoolDataSnapshot.fromJson(roundTripped);
 
       expect(restored, isNotNull);
       expect(restored!.me?.id, 'su-1');
       expect(restored.me?.firstName, 'Ada');
       expect(restored.me?.lastName, 'Byron');
+      expect(restored.me?.role, Roles.student);
+      expect(restored.me?.state, UserState.active);
+      expect(restored.me?.birthday, Date(2000, 1, 1));
+      expect(restored.me?.grades?.single.score, 5.5);
+      expect(restored.me?.classes?.single.classId, 'c-1');
       expect(restored.exams.length, 2);
       expect(restored.exams.first.id, 'e-1');
+      expect(restored.exams.first.type, ExamType.classic);
       expect(restored.exams.first.date, Date(2026, 3, 12));
       expect(restored.exams.first.grades?.single.score, 5.5);
+      expect(restored.exams.last.type, ExamType.finalExam);
+      expect(restored.agenda.map((a) => a.entryType), containsAll(AgendaEntryType.values));
       expect(restored.absences.single.reason, 'Sick');
       expect(restored.classes.single.name, '4a');
+      expect(restored.reports.single.subjects?.single.subjectCode, 'MATH');
+      expect(restored.teachers.single.code, 'JD');
+      expect(restored.documents.single.followUpDate, Date(2026, 5, 1));
+      expect(restored.documents.single.notifiedAt, DateTime.utc(2026, 4, 1));
+    });
+
+    test('non-finite doubles do not break jsonEncode and round-trip intact', () {
+      // built_value's DoubleSerializer turns NaN/Infinity into sentinel
+      // strings ('NaN' / 'INF' / '-INF') before jsonEncode ever sees a raw
+      // double, and reverses that on decode - guard this behaviour so a
+      // built_value upgrade that drops it is caught here, not on a device.
+      final exams = [
+        ExamDto((b) => b
+          ..id = 'e-1'
+          ..name = 'Bad average'
+          ..classAverage = double.nan
+          ..schoolId = 's-1'
+          ..grades.add(GradeDto((g) => g
+            ..id = 'g-1'
+            ..score = double.infinity
+            ..examId = 'e-1'
+            ..schoolUserId = 'su-1'))),
+      ];
+
+      final snapshot = SchoolDataSnapshot(me: null, exams: exams, agenda: const [], absences: const [], classes: const [], reports: const [], teachers: const [], documents: const []);
+
+      final encoded = jsonEncode(snapshot.toJson());
+      final restored = SchoolDataSnapshot.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
+
+      expect(restored, isNotNull);
+      expect(restored!.exams.single.classAverage.isNaN, isTrue);
+      expect(restored.exams.single.grades?.single.score, double.infinity);
+    });
+
+    test('skips an unreadable item instead of discarding the whole list', () {
+      final json = {
+        'version': 1,
+        'me': null,
+        'exams': [
+          {'id': 'e-1', 'name': 'Midterm', 'classAverage': 4.5},
+          'not an exam',
+        ],
+        'agenda': const [],
+        'absences': const [],
+        'classes': const [],
+        'reports': const [],
+        'teachers': const [],
+        'documents': const [],
+      };
+
+      final restored = SchoolDataSnapshot.fromJson(json);
+
+      expect(restored, isNotNull);
+      expect(restored!.exams.length, 1);
+      expect(restored.exams.single.id, 'e-1');
     });
 
     test('returns null for an unknown version', () {

--- a/test/school_data_service_test.dart
+++ b/test/school_data_service_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/services/school_data_service.dart';
+import 'package:schuly/services/school_data_snapshot.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+void main() {
+  group('SchoolDataSnapshot', () {
+    test('round-trips through json', () {
+      final me = SchoolUserDto((b) => b
+        ..firstName = 'Ada'
+        ..lastName = 'Byron'
+        ..email = 'ada@example.com'
+        ..id = 'su-1'
+        ..schoolId = 's-1'
+        ..role = Roles.student);
+
+      final exams = [
+        ExamDto((b) => b
+          ..id = 'e-1'
+          ..name = 'Midterm'
+          ..classAverage = 4.5
+          ..date = Date(2026, 3, 12)
+          ..schoolId = 's-1'
+          ..grades.add(GradeDto((g) => g
+            ..id = 'g-1'
+            ..score = 5.5
+            ..weighting = 1
+            ..examId = 'e-1'
+            ..schoolUserId = 'su-1'))),
+        ExamDto((b) => b
+          ..id = 'e-2'
+          ..name = 'Final'
+          ..classAverage = 4.0
+          ..schoolId = 's-1'),
+      ];
+
+      final absences = [
+        AbsenceDto((b) => b
+          ..id = 'a-1'
+          ..reason = 'Sick'
+          ..type = AbsenceType.absence
+          ..from = DateTime.utc(2026, 1, 5)
+          ..until = DateTime.utc(2026, 1, 6)
+          ..schoolUserId = 'su-1'
+          ..schoolId = 's-1'),
+      ];
+
+      final classes = [
+        ClassDto((b) => b
+          ..id = 'c-1'
+          ..name = '4a'
+          ..schoolId = 's-1'),
+      ];
+
+      final snapshot = SchoolDataSnapshot(me: me, exams: exams, agenda: const [], absences: absences, classes: classes, reports: const [], teachers: const [], documents: const []);
+
+      final roundTripped = jsonDecode(jsonEncode(snapshot.toJson())) as Map<String, dynamic>;
+      final restored = SchoolDataSnapshot.fromJson(roundTripped);
+
+      expect(restored, isNotNull);
+      expect(restored!.me?.id, 'su-1');
+      expect(restored.me?.firstName, 'Ada');
+      expect(restored.me?.lastName, 'Byron');
+      expect(restored.exams.length, 2);
+      expect(restored.exams.first.id, 'e-1');
+      expect(restored.exams.first.date, Date(2026, 3, 12));
+      expect(restored.exams.first.grades?.single.score, 5.5);
+      expect(restored.absences.single.reason, 'Sick');
+      expect(restored.classes.single.name, '4a');
+    });
+
+    test('returns null for an unknown version', () {
+      expect(SchoolDataSnapshot.fromJson({'version': 99}), isNull);
+    });
+
+    test('returns null instead of throwing on malformed data', () {
+      expect(SchoolDataSnapshot.fromJson({'version': 1, 'exams': 'nope'}), isNull);
+    });
+  });
+
+  group('SchoolDataService', () {
+    test('refresh with no active school settles into the empty loaded state', () async {
+      await SchoolDataService.instance.refresh();
+
+      expect(SchoolDataService.instance.hasLoaded, isTrue);
+      expect(SchoolDataService.instance.me, isNull);
+      expect(SchoolDataService.instance.loading, isFalse);
+      expect(SchoolDataService.instance.exams, isEmpty);
+
+      SchoolDataService.instance.clear();
+      expect(SchoolDataService.instance.hasLoaded, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `SchoolDataService.refresh()` now takes a generation number, builds every result into locals and commits them in one step; a superseded refresh returns without touching state or the loading flag, so switching school can no longer mix two accounts' data. `clear()` bumps the generation too.
- Removed the duplicate cold-start refresh in `DashboardScreen._bootstrap` (`ActiveAccountService.refresh()` notifies before it returns, so `_onActiveChanged` had already started an identical one).
- The service tracks the key (mode + school id) its data belongs to and drops it at the top of a refresh whose key differs, so private and account data can never be shown against the wrong session. Sign-out clears the service and its on-disk cache in both branches, as does the `sessionEpoch` listener; disconnecting a school drops the cache.
- Refresh failures now raise a toast when data is already on screen, in both modes. The service's own requests are marked `ApiClient.handlesErrors` so the global interceptor no longer fires one toast per parallel request.
- The seven independent list endpoints are fetched with `Future.wait` after `me`.
- The last successful snapshot is persisted as JSON in the app support directory (keyed by mode + school id, encoded with the generated `standardSerializers`) and loaded before the first frame, so launch renders real data while the refresh runs in the background. The cache is invalidated on sign-out and on school removal, and is discarded silently if it fails to read.
- A `hasLoaded` flag drives a spinner overlay on top of the `IndexedStack` instead of replacing it, so the empty-home flash is gone and page state survives the first load.
- The access token and its expiry are persisted in `flutter_secure_storage` alongside the refresh token, so a cold start skips the OIDC discovery + refresh round trip while the token is still valid (30s margin).

Closes #477
Closes #478
Closes #481
Closes #488
