### PR TITLE
Port the legacy timetable UI with break cards and a timeline view

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -6,5 +6,15 @@
   "tabGrades": "Noten",
   "tabAbsences": "Absenzen",
   "tabAccount": "Konto",
-  "signIn": "Anmelden"
+  "signIn": "Anmelden",
+  "lessonFrom": "von",
+  "lessonUntil": "bis",
+  "breakDuration": "Pause ({minutes} min)",
+  "lunchBreakDuration": "Mittagspause ({minutes} min)",
+  "minutesLeft": "noch {minutes} min",
+  "nothingScheduled": "Nichts geplant",
+  "entryTypeLesson": "Lektion",
+  "entryTypeTest": "Prüfung",
+  "entryTypeEvent": "Termin",
+  "entryTypeHoliday": "Ferien"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9,5 +9,54 @@
   "tabGrades": "Grades",
   "tabAbsences": "Absences",
   "tabAccount": "Account",
-  "signIn": "Sign in"
+  "signIn": "Sign in",
+  "lessonFrom": "from",
+  "@lessonFrom": {
+    "description": "Label preceding a lesson's start time"
+  },
+  "lessonUntil": "until",
+  "@lessonUntil": {
+    "description": "Label preceding a lesson's end time"
+  },
+  "breakDuration": "Break ({minutes} min)",
+  "@breakDuration": {
+    "description": "Label for a short break with its duration in minutes",
+    "placeholders": {
+      "minutes": {"type": "int"}
+    }
+  },
+  "lunchBreakDuration": "Lunch break ({minutes} min)",
+  "@lunchBreakDuration": {
+    "description": "Label for a lunch break with its duration in minutes",
+    "placeholders": {
+      "minutes": {"type": "int"}
+    }
+  },
+  "minutesLeft": "{minutes} min left",
+  "@minutesLeft": {
+    "description": "Remaining time for the current lesson or break",
+    "placeholders": {
+      "minutes": {"type": "int"}
+    }
+  },
+  "nothingScheduled": "Nothing scheduled",
+  "@nothingScheduled": {
+    "description": "Empty state when a selected day has no agenda entries"
+  },
+  "entryTypeLesson": "Lesson",
+  "@entryTypeLesson": {
+    "description": "Agenda entry type label for a regular lesson"
+  },
+  "entryTypeTest": "Test",
+  "@entryTypeTest": {
+    "description": "Agenda entry type label for a test"
+  },
+  "entryTypeEvent": "Event",
+  "@entryTypeEvent": {
+    "description": "Agenda entry type label for an event"
+  },
+  "entryTypeHoliday": "Holiday",
+  "@entryTypeHoliday": {
+    "description": "Agenda entry type label for a holiday"
+  }
 }

--- a/lib/ui/core/ui/now_ticker.dart
+++ b/lib/ui/core/ui/now_ticker.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+class NowTicker extends StatefulWidget {
+  const NowTicker({super.key, required this.builder, this.interval = const Duration(seconds: 30)});
+
+  final Widget Function(BuildContext context, DateTime now) builder;
+  final Duration interval;
+
+  @override
+  State<NowTicker> createState() => _NowTickerState();
+}
+
+class _NowTickerState extends State<NowTicker> {
+  DateTime _now = DateTime.now();
+  late Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _startTimer();
+  }
+
+  void _startTimer() {
+    _timer = Timer.periodic(widget.interval, (_) => setState(() => _now = DateTime.now()));
+  }
+
+  @override
+  void didUpdateWidget(covariant NowTicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.interval != widget.interval) {
+      _timer.cancel();
+      _startTimer();
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(context, _now);
+}

--- a/lib/ui/core/ui/now_ticker.dart
+++ b/lib/ui/core/ui/now_ticker.dart
@@ -12,13 +12,14 @@ class NowTicker extends StatefulWidget {
   State<NowTicker> createState() => _NowTickerState();
 }
 
-class _NowTickerState extends State<NowTicker> {
+class _NowTickerState extends State<NowTicker> with WidgetsBindingObserver {
   DateTime _now = DateTime.now();
   late Timer _timer;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _startTimer();
   }
 
@@ -35,8 +36,18 @@ class _NowTickerState extends State<NowTicker> {
     }
   }
 
+  // The periodic timer alone can leave `now` stale for as long as the app was
+  // backgrounded (Android/iOS suspend timers while paused) - refresh
+  // immediately when the app comes back to the foreground instead of waiting
+  // for the next tick.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) setState(() => _now = DateTime.now());
+  }
+
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _timer.cancel();
     super.dispose();
   }

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -33,9 +33,6 @@ class HomePage extends StatelessWidget {
     final todayEntries = svc.agenda.where((a) => !isHoliday(a) && sameDay(a.date)).toList()
       ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
 
-    final upcoming = svc.agenda.where((a) => !isHoliday(a) && dayOf(a.date).isAfter(today)).toList()
-      ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
-
     final holidays = svc.agenda
         .where((a) => isHoliday(a) && !dayOf(a.endDate ?? a.date).isBefore(today))
         .toList()
@@ -95,19 +92,6 @@ class HomePage extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         _Section(
-          title: 'Upcoming',
-          emptyText: 'Nothing upcoming',
-          tiles: [
-            for (final t in upcoming.take(5))
-              FTile(
-                prefix: const Icon(FIcons.calendarDays),
-                title: Text(t.title.isNotEmpty == true ? t.title : 'Entry'),
-                subtitle: Text('${_dateLabel(t.date)} · ${_time(t.date)}'),
-              ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        _Section(
           title: 'Next holiday',
           emptyText: 'No upcoming holidays',
           tiles: [
@@ -151,12 +135,6 @@ class HomePage extends StatelessWidget {
       ],
       ),
     );
-  }
-
-  static String _time(DateTime d) {
-    final h = d.hour.toString().padLeft(2, '0');
-    final m = d.minute.toString().padLeft(2, '0');
-    return '$h:$m';
   }
 
   static String _dateLabel(DateTime d) {

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -4,6 +4,10 @@ import 'package:schuly_api/schuly_api.dart';
 
 import '../../services/school_data_service.dart';
 import '../core/grade_color.dart';
+import '../core/ui/now_ticker.dart';
+import '../timetable/break_card.dart';
+import '../timetable/day_schedule.dart';
+import '../timetable/lesson_tile.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -14,21 +18,28 @@ class HomePage extends StatelessWidget {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
 
-    bool sameDay(DateTime d) => d.year == today.year && d.month == today.month && d.day == today.day;
-    DateTime dayOf(DateTime d) => DateTime(d.year, d.month, d.day);
+    bool sameDay(DateTime d) {
+      final local = d.toLocal();
+      return local.year == today.year && local.month == today.month && local.day == today.day;
+    }
+
+    DateTime dayOf(DateTime d) {
+      final local = d.toLocal();
+      return DateTime(local.year, local.month, local.day);
+    }
 
     bool isHoliday(AgendaEntryDto a) => a.entryType == AgendaEntryType.holiday;
 
     final todayEntries = svc.agenda.where((a) => !isHoliday(a) && sameDay(a.date)).toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
+      ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
 
     final upcoming = svc.agenda.where((a) => !isHoliday(a) && dayOf(a.date).isAfter(today)).toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
+      ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
 
     final holidays = svc.agenda
         .where((a) => isHoliday(a) && !dayOf(a.endDate ?? a.date).isBefore(today))
         .toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
+      ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
 
     final myGrades = svc.myGradesByExam;
     final examById = {for (final e in svc.exams) e.id: e};
@@ -61,11 +72,24 @@ class HomePage extends StatelessWidget {
           title: 'Today',
           emptyText: 'Nothing scheduled today',
           tiles: [
-            for (final l in todayEntries)
-              FTile(
-                prefix: const Icon(FIcons.calendarDays),
-                title: Text(l.title.isNotEmpty == true ? l.title : 'Entry'),
-                subtitle: Text([_time(l.date), l.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
+            if (todayEntries.isNotEmpty)
+              NowTicker(
+                builder: (context, now) {
+                  final items = buildDaySchedule(todayEntries);
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      for (final item in items)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: switch (item) {
+                            LessonItem lesson => LessonTile(item: lesson, now: now),
+                            BreakItem brk => BreakCard(item: brk, now: now),
+                          },
+                        ),
+                    ],
+                  );
+                },
               ),
           ],
         ),

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -4,48 +4,30 @@ import 'package:forui/forui.dart';
 import '../../l10n/app_localizations.dart';
 import 'day_schedule.dart';
 
+/// A gap between two lessons, in the same tile style as the lessons around it.
 class BreakCard extends StatelessWidget {
-  const BreakCard({super.key, required this.item, required this.now});
+  const BreakCard({super.key, required this.item, required this.now, this.showTime = true});
 
   final BreakItem item;
   final DateTime now;
 
+  /// Whether the time range is part of the subtitle. The timetable's timeline
+  /// already shows it in its own column.
+  final bool showTime;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
-    final typography = context.theme.typography;
     final t = AppLocalizations.of(context)!;
     final current = item.isCurrentAt(now);
 
     final label = item.isLunch ? t.lunchBreakDuration(item.minutes) : t.breakDuration(item.minutes);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
-      decoration: BoxDecoration(
-        color: current ? colors.primary.withValues(alpha: 0.12) : Colors.transparent,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: current ? colors.primary.withValues(alpha: 0.5) : colors.border,
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(item.isLunch ? FIcons.utensils : FIcons.coffee,
-              size: 14, color: current ? colors.primary : colors.mutedForeground),
-          const SizedBox(width: 6),
-          Text(label,
-              style: typography.xs.copyWith(
-                color: current ? colors.primary : colors.mutedForeground,
-                fontWeight: current ? FontWeight.w500 : FontWeight.normal,
-              )),
-          if (current) ...[
-            const SizedBox(width: 6),
-            Text('· ${t.minutesLeft(item.remainingMinutesAt(now))}',
-                style: typography.xs.copyWith(color: colors.primary, fontWeight: FontWeight.w500)),
-          ],
-        ],
-      ),
+    return FTile(
+      prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, color: current ? colors.primary : null),
+      title: Text(label),
+      subtitle: showTime ? Text('${formatHm(item.start)} – ${formatHm(item.end)}') : null,
+      details: current ? Text(t.minutesLeft(item.remainingMinutesAt(now))) : null,
     );
   }
 }

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -20,6 +20,7 @@ class BreakCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
+    final typography = context.theme.typography;
     final t = AppLocalizations.of(context)!;
     final current = item.isCurrentAt(now);
 
@@ -34,17 +35,17 @@ class BreakCard extends StatelessWidget {
     final Widget title;
     if (!showTime && remaining != null) {
       title = Text.rich(TextSpan(children: [
-        TextSpan(text: '$base · ', style: TextStyle(color: colors.mutedForeground)),
-        TextSpan(text: remaining, style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600)),
+        TextSpan(text: '$base · ', style: typography.sm.copyWith(color: colors.mutedForeground)),
+        TextSpan(text: remaining, style: typography.sm.copyWith(color: colors.primary, fontWeight: FontWeight.w600)),
       ]));
     } else {
-      title = Text(base, style: TextStyle(color: colors.mutedForeground));
+      title = Text(base, style: typography.sm.copyWith(color: colors.mutedForeground));
     }
 
     return FTile(
       style: (style) =>
           style.copyWith(contentStyle: (content) => content.copyWith(padding: const EdgeInsetsDirectional.fromSTEB(15, 6, 10, 6))),
-      prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, size: 16, color: colors.mutedForeground),
+      prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, size: 14, color: colors.mutedForeground),
       title: title,
       details: showTime && remaining != null
           ? Text(remaining, style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600))

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../l10n/app_localizations.dart';
+import 'day_schedule.dart';
+
+class BreakCard extends StatelessWidget {
+  const BreakCard({super.key, required this.item, required this.now});
+
+  final BreakItem item;
+  final DateTime now;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final t = AppLocalizations.of(context)!;
+    final current = item.isCurrentAt(now);
+
+    final label = item.isLunch ? t.lunchBreakDuration(item.minutes) : t.breakDuration(item.minutes);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+      decoration: BoxDecoration(
+        color: current ? colors.primary.withValues(alpha: 0.12) : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: current ? colors.primary.withValues(alpha: 0.5) : colors.border.withValues(alpha: 0.4),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(item.isLunch ? FIcons.utensils : FIcons.coffee,
+              size: 14, color: current ? colors.primary : colors.mutedForeground),
+          const SizedBox(width: 6),
+          Text(label,
+              style: typography.xs.copyWith(
+                color: current ? colors.primary : colors.mutedForeground,
+                fontWeight: current ? FontWeight.w500 : FontWeight.normal,
+              )),
+          if (current) ...[
+            const SizedBox(width: 6),
+            Text('· ${t.minutesLeft(item.remainingMinutesAt(now))}',
+                style: typography.xs.copyWith(color: colors.primary, fontWeight: FontWeight.w500)),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -25,14 +25,29 @@ class BreakCard extends StatelessWidget {
 
     final label = item.isLunch ? t.lunchBreakDuration(item.minutes) : t.breakDuration(item.minutes);
     final range = showTime ? '${formatHm(item.start)} – ${formatHm(item.end)}' : null;
+    final base = range == null ? label : '$label · $range';
+    final remaining = current ? t.minutesLeft(item.remainingMinutesAt(now)) : null;
+
+    // The timeline's tile is narrow, so "details" ellipsises there - fold the
+    // remaining-minutes text into the title instead. The home page keeps the
+    // roomier "details" slot.
+    final Widget title;
+    if (!showTime && remaining != null) {
+      title = Text.rich(TextSpan(children: [
+        TextSpan(text: '$base · ', style: TextStyle(color: colors.mutedForeground)),
+        TextSpan(text: remaining, style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600)),
+      ]));
+    } else {
+      title = Text(base, style: TextStyle(color: colors.mutedForeground));
+    }
 
     return FTile(
       style: (style) =>
           style.copyWith(contentStyle: (content) => content.copyWith(padding: const EdgeInsetsDirectional.fromSTEB(15, 6, 10, 6))),
       prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, size: 16, color: colors.mutedForeground),
-      title: Text(range == null ? label : '$label · $range', style: TextStyle(color: colors.mutedForeground)),
-      details: current
-          ? Text(t.minutesLeft(item.remainingMinutesAt(now)), style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600))
+      title: title,
+      details: showTime && remaining != null
+          ? Text(remaining, style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600))
           : null,
     );
   }

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -25,7 +25,7 @@ class BreakCard extends StatelessWidget {
         color: current ? colors.primary.withValues(alpha: 0.12) : Colors.transparent,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: current ? colors.primary.withValues(alpha: 0.5) : colors.border.withValues(alpha: 0.4),
+          color: current ? colors.primary.withValues(alpha: 0.5) : colors.border,
         ),
       ),
       child: Row(

--- a/lib/ui/timetable/break_card.dart
+++ b/lib/ui/timetable/break_card.dart
@@ -1,18 +1,20 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 
 import '../../l10n/app_localizations.dart';
 import 'day_schedule.dart';
 
-/// A gap between two lessons, in the same tile style as the lessons around it.
+/// A gap between two lessons. Kept in the same outlined tile language as
+/// [LessonTile] but visibly slimmer and muted, since breaks are secondary
+/// information: single line, tighter padding, no subtitle row.
 class BreakCard extends StatelessWidget {
   const BreakCard({super.key, required this.item, required this.now, this.showTime = true});
 
   final BreakItem item;
   final DateTime now;
 
-  /// Whether the time range is part of the subtitle. The timetable's timeline
-  /// already shows it in its own column.
+  /// Whether the time range is appended to the label. The timetable's
+  /// timeline already shows it in its own column.
   final bool showTime;
 
   @override
@@ -22,12 +24,16 @@ class BreakCard extends StatelessWidget {
     final current = item.isCurrentAt(now);
 
     final label = item.isLunch ? t.lunchBreakDuration(item.minutes) : t.breakDuration(item.minutes);
+    final range = showTime ? '${formatHm(item.start)} – ${formatHm(item.end)}' : null;
 
     return FTile(
-      prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, color: current ? colors.primary : null),
-      title: Text(label),
-      subtitle: showTime ? Text('${formatHm(item.start)} – ${formatHm(item.end)}') : null,
-      details: current ? Text(t.minutesLeft(item.remainingMinutesAt(now))) : null,
+      style: (style) =>
+          style.copyWith(contentStyle: (content) => content.copyWith(padding: const EdgeInsetsDirectional.fromSTEB(15, 6, 10, 6))),
+      prefix: Icon(item.isLunch ? FIcons.utensils : FIcons.coffee, size: 16, color: colors.mutedForeground),
+      title: Text(range == null ? label : '$label · $range', style: TextStyle(color: colors.mutedForeground)),
+      details: current
+          ? Text(t.minutesLeft(item.remainingMinutesAt(now)), style: TextStyle(color: colors.primary, fontWeight: FontWeight.w600))
+          : null,
     );
   }
 }

--- a/lib/ui/timetable/day_schedule.dart
+++ b/lib/ui/timetable/day_schedule.dart
@@ -1,0 +1,89 @@
+import 'package:schuly_api/schuly_api.dart';
+
+const Duration kFallbackLessonDuration = Duration(minutes: 45);
+const int kMinBreakMinutes = 5;
+const int kMaxBreakMinutes = 120;
+const int kMinLunchBreakMinutes = 30;
+
+sealed class DayItem {
+  DateTime get start;
+  DateTime get end;
+
+  bool isCurrentAt(DateTime now) => !now.isBefore(start) && now.isBefore(end);
+
+  Duration remainingAt(DateTime now) => end.difference(now);
+
+  // Only meaningful while isCurrentAt(now) is true, in which case now < end
+  // already guarantees the ceiling is at least 1 minute.
+  int remainingMinutesAt(DateTime now) => (remainingAt(now).inSeconds / 60).ceil();
+}
+
+final class LessonItem extends DayItem {
+  LessonItem(this.entry);
+
+  final AgendaEntryDto entry;
+
+  @override
+  DateTime get start => entry.date.toLocal();
+
+  bool get hasEndTime => entry.endDate != null;
+
+  @override
+  // Entries without a server-provided end time still need a layout end point;
+  // 45 minutes is a reasonable default lesson length, not a real schedule fact.
+  DateTime get end => hasEndTime ? entry.endDate!.toLocal() : start.add(kFallbackLessonDuration);
+}
+
+final class BreakItem extends DayItem {
+  BreakItem({required this.start, required this.end});
+
+  @override
+  final DateTime start;
+
+  @override
+  final DateTime end;
+
+  int get minutes => end.difference(start).inMinutes;
+
+  bool get isLunch {
+    if (minutes < kMinLunchBreakMinutes) return false;
+    const windowStart = 11 * 60;
+    const windowEnd = 13 * 60 + 30;
+    final startMinuteOfDay = start.hour * 60 + start.minute;
+    final endMinuteOfDay = end.hour * 60 + end.minute;
+    return startMinuteOfDay >= windowStart && endMinuteOfDay <= windowEnd;
+  }
+}
+
+List<DayItem> buildDaySchedule(List<AgendaEntryDto> entries, {bool withBreaks = true}) {
+  final sorted = List<AgendaEntryDto>.of(entries)
+    ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
+
+  final items = <DayItem>[];
+  DateTime? previousEnd;
+  for (final entry in sorted) {
+    final lesson = LessonItem(entry);
+    if (withBreaks && previousEnd != null) {
+      final gapMinutes = lesson.start.difference(previousEnd).inMinutes;
+      if (gapMinutes >= kMinBreakMinutes && gapMinutes <= kMaxBreakMinutes) {
+        items.add(BreakItem(start: previousEnd, end: lesson.start));
+      }
+    }
+    items.add(lesson);
+    previousEnd = lesson.end;
+  }
+  return items;
+}
+
+DayItem? currentItem(List<DayItem> items, DateTime now) {
+  for (final item in items) {
+    if (item.isCurrentAt(now)) return item;
+  }
+  return null;
+}
+
+String formatHm(DateTime d) {
+  final h = d.hour.toString().padLeft(2, '0');
+  final m = d.minute.toString().padLeft(2, '0');
+  return '$h:$m';
+}

--- a/lib/ui/timetable/day_schedule.dart
+++ b/lib/ui/timetable/day_schedule.dart
@@ -87,3 +87,9 @@ String formatHm(DateTime d) {
   final m = d.minute.toString().padLeft(2, '0');
   return '$h:$m';
 }
+
+final RegExp _shortCodeSuffix = RegExp(r'\s*\([A-Za-z]{2,6}\)\s*$');
+
+// The API's description field appends a trailing teacher short code, e.g.
+// "Bachofner Manuel (BaMa)". Strip it for display; leave anything else as is.
+String stripShortCode(String s) => s.replaceFirst(_shortCodeSuffix, '');

--- a/lib/ui/timetable/entry_style.dart
+++ b/lib/ui/timetable/entry_style.dart
@@ -1,38 +1,20 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 import 'package:schuly_api/schuly_api.dart';
 
 import '../../l10n/app_localizations.dart';
 
-({String label, Color color, IconData icon}) entryStyle(BuildContext context, AgendaEntryType type) {
-  final colors = context.theme.colors;
+({String label, IconData icon}) entryStyle(BuildContext context, AgendaEntryType type) {
   final t = AppLocalizations.of(context)!;
   switch (type) {
     case AgendaEntryType.test:
-      return (label: t.entryTypeTest, color: const Color(0xFFEF4444), icon: FIcons.clipboardList);
+      return (label: t.entryTypeTest, icon: FIcons.clipboardList);
     case AgendaEntryType.event:
-      return (label: t.entryTypeEvent, color: const Color(0xFF22C55E), icon: FIcons.calendarHeart);
+      return (label: t.entryTypeEvent, icon: FIcons.calendarHeart);
     case AgendaEntryType.holiday:
-      return (label: t.entryTypeHoliday, color: const Color(0xFFF59E0B), icon: FIcons.treePalm);
+      return (label: t.entryTypeHoliday, icon: FIcons.treePalm);
     case AgendaEntryType.lesson:
     default:
-      return (label: t.entryTypeLesson, color: colors.primary, icon: FIcons.bookOpen);
+      return (label: t.entryTypeLesson, icon: FIcons.bookOpen);
   }
-}
-
-class EntryTypeBadge extends StatelessWidget {
-  final String label;
-  final Color color;
-  const EntryTypeBadge({super.key, required this.label, required this.color});
-
-  @override
-  Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.16),
-          borderRadius: BorderRadius.circular(6),
-        ),
-        child: Text(label,
-            style: TextStyle(color: color, fontWeight: FontWeight.w600, fontSize: 12)),
-      );
 }

--- a/lib/ui/timetable/entry_style.dart
+++ b/lib/ui/timetable/entry_style.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../l10n/app_localizations.dart';
+
+({String label, Color color, IconData icon}) entryStyle(BuildContext context, AgendaEntryType type) {
+  final colors = context.theme.colors;
+  final t = AppLocalizations.of(context)!;
+  switch (type) {
+    case AgendaEntryType.test:
+      return (label: t.entryTypeTest, color: const Color(0xFFEF4444), icon: FIcons.clipboardList);
+    case AgendaEntryType.event:
+      return (label: t.entryTypeEvent, color: const Color(0xFF22C55E), icon: FIcons.calendarHeart);
+    case AgendaEntryType.holiday:
+      return (label: t.entryTypeHoliday, color: const Color(0xFFF59E0B), icon: FIcons.treePalm);
+    case AgendaEntryType.lesson:
+    default:
+      return (label: t.entryTypeLesson, color: colors.primary, icon: FIcons.bookOpen);
+  }
+}
+
+class EntryTypeBadge extends StatelessWidget {
+  final String label;
+  final Color color;
+  const EntryTypeBadge({super.key, required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.16),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text(label,
+            style: TextStyle(color: color, fontWeight: FontWeight.w600, fontSize: 12)),
+      );
+}

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 
 import '../../l10n/app_localizations.dart';

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -27,10 +27,11 @@ class LessonTile extends StatelessWidget {
     final time = item.hasEndTime
         ? '${formatHm(item.start)} – ${formatHm(item.end)}'
         : formatHm(item.start);
+    final description = item.entry.description;
     final subtitleText = [
       if (showTime) time,
       item.entry.place,
-      item.entry.description,
+      description == null ? null : stripShortCode(description),
     ].where((s) => s != null && s.isNotEmpty).join(' · ');
     final remaining = current ? t.minutesLeft(item.remainingMinutesAt(now)) : null;
 

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../l10n/app_localizations.dart';
+import 'day_schedule.dart';
+import 'entry_style.dart';
+
+class LessonTile extends StatelessWidget {
+  const LessonTile({super.key, required this.item, required this.now});
+
+  final LessonItem item;
+  final DateTime now;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final t = AppLocalizations.of(context)!;
+    final style = entryStyle(context, item.entry.entryType);
+    final current = item.isCurrentAt(now);
+    final borderColor = current ? style.color : style.color.withValues(alpha: 0.4);
+
+    final place = item.entry.place;
+    final description = item.entry.description;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.secondary,
+        borderRadius: BorderRadius.circular(8),
+        border: Border(left: BorderSide(color: borderColor, width: 4)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${t.lessonFrom} ${formatHm(item.start)}',
+                  style: typography.xs.copyWith(color: colors.mutedForeground)),
+              if (item.hasEndTime)
+                Text('${t.lessonUntil} ${formatHm(item.end)}',
+                    style: typography.xs.copyWith(color: colors.mutedForeground)),
+            ],
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(style.icon, size: 14, color: style.color),
+                    const SizedBox(width: 4),
+                    Flexible(
+                      child: Text(item.entry.title,
+                          style: typography.sm.copyWith(fontWeight: FontWeight.w600)),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 4,
+                  children: [
+                    if (place != null && place.isNotEmpty)
+                      _IconLabel(icon: FIcons.mapPin, label: place),
+                    if (description != null && description.isNotEmpty)
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 150),
+                        child: _IconLabel(icon: FIcons.user, label: description, ellipsis: true),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          if (current) _RemainingChip(label: t.minutesLeft(item.remainingMinutesAt(now))),
+        ],
+      ),
+    );
+  }
+}
+
+class _IconLabel extends StatelessWidget {
+  const _IconLabel({required this.icon, required this.label, this.ellipsis = false});
+
+  final IconData icon;
+  final String label;
+  final bool ellipsis;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: colors.mutedForeground),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            label,
+            style: typography.xs.copyWith(color: colors.mutedForeground),
+            overflow: ellipsis ? TextOverflow.ellipsis : TextOverflow.visible,
+            maxLines: 1,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RemainingChip extends StatelessWidget {
+  const _RemainingChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(FIcons.clock, size: 14, color: colors.primary),
+        const SizedBox(width: 4),
+        Text(label, style: typography.xs.copyWith(color: colors.primary, fontWeight: FontWeight.w600)),
+      ],
+    );
+  }
+}

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -27,17 +27,31 @@ class LessonTile extends StatelessWidget {
     final time = item.hasEndTime
         ? '${formatHm(item.start)} – ${formatHm(item.end)}'
         : formatHm(item.start);
-    final subtitle = [
+    final subtitleText = [
       if (showTime) time,
       item.entry.place,
       item.entry.description,
     ].where((s) => s != null && s.isNotEmpty).join(' · ');
+    final remaining = current ? t.minutesLeft(item.remainingMinutesAt(now)) : null;
+
+    // The timeline's tile is narrow, so "details" ellipsises there - fold the
+    // remaining-minutes text into the subtitle instead. The home page keeps
+    // the roomier "details" slot.
+    final Widget? subtitle;
+    if (!showTime && remaining != null) {
+      subtitle = Text.rich(TextSpan(children: [
+        if (subtitleText.isNotEmpty) TextSpan(text: '$subtitleText · '),
+        TextSpan(text: remaining, style: TextStyle(color: colors.primary)),
+      ]));
+    } else {
+      subtitle = subtitleText.isEmpty ? null : Text(subtitleText);
+    }
 
     return FTile(
       prefix: Icon(style.icon, color: current ? colors.primary : null),
       title: Text(item.entry.title.isNotEmpty ? item.entry.title : style.label),
-      subtitle: subtitle.isEmpty ? null : Text(subtitle),
-      details: current ? Text(t.minutesLeft(item.remainingMinutesAt(now))) : null,
+      subtitle: subtitle,
+      details: showTime && remaining != null ? Text(remaining) : null,
     );
   }
 }

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -18,17 +18,16 @@ class LessonTile extends StatelessWidget {
     final t = AppLocalizations.of(context)!;
     final style = entryStyle(context, item.entry.entryType);
     final current = item.isCurrentAt(now);
-    final borderColor = current ? style.color : style.color.withValues(alpha: 0.4);
+    final borderColor = current ? colors.primary : colors.border;
 
     final place = item.entry.place;
     final description = item.entry.description;
 
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
       decoration: BoxDecoration(
-        color: colors.secondary,
         borderRadius: BorderRadius.circular(8),
-        border: Border(left: BorderSide(color: borderColor, width: 4)),
+        border: Border.all(color: borderColor, width: current ? 1.5 : 1),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/ui/timetable/lesson_tile.dart
+++ b/lib/ui/timetable/lesson_tile.dart
@@ -5,127 +5,39 @@ import '../../l10n/app_localizations.dart';
 import 'day_schedule.dart';
 import 'entry_style.dart';
 
+/// A lesson on the home page, styled like every other home tile: icon prefix,
+/// title, one-line subtitle, optional detail on the right.
 class LessonTile extends StatelessWidget {
-  const LessonTile({super.key, required this.item, required this.now});
+  const LessonTile({super.key, required this.item, required this.now, this.showTime = true});
 
   final LessonItem item;
   final DateTime now;
 
+  /// Whether the time range is part of the subtitle. The timetable's timeline
+  /// already shows it in its own column.
+  final bool showTime;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
-    final typography = context.theme.typography;
     final t = AppLocalizations.of(context)!;
     final style = entryStyle(context, item.entry.entryType);
     final current = item.isCurrentAt(now);
-    final borderColor = current ? colors.primary : colors.border;
 
-    final place = item.entry.place;
-    final description = item.entry.description;
+    final time = item.hasEndTime
+        ? '${formatHm(item.start)} – ${formatHm(item.end)}'
+        : formatHm(item.start);
+    final subtitle = [
+      if (showTime) time,
+      item.entry.place,
+      item.entry.description,
+    ].where((s) => s != null && s.isNotEmpty).join(' · ');
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: borderColor, width: current ? 1.5 : 1),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('${t.lessonFrom} ${formatHm(item.start)}',
-                  style: typography.xs.copyWith(color: colors.mutedForeground)),
-              if (item.hasEndTime)
-                Text('${t.lessonUntil} ${formatHm(item.end)}',
-                    style: typography.xs.copyWith(color: colors.mutedForeground)),
-            ],
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(style.icon, size: 14, color: style.color),
-                    const SizedBox(width: 4),
-                    Flexible(
-                      child: Text(item.entry.title,
-                          style: typography.sm.copyWith(fontWeight: FontWeight.w600)),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Wrap(
-                  spacing: 12,
-                  runSpacing: 4,
-                  children: [
-                    if (place != null && place.isNotEmpty)
-                      _IconLabel(icon: FIcons.mapPin, label: place),
-                    if (description != null && description.isNotEmpty)
-                      ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 150),
-                        child: _IconLabel(icon: FIcons.user, label: description, ellipsis: true),
-                      ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          if (current) _RemainingChip(label: t.minutesLeft(item.remainingMinutesAt(now))),
-        ],
-      ),
-    );
-  }
-}
-
-class _IconLabel extends StatelessWidget {
-  const _IconLabel({required this.icon, required this.label, this.ellipsis = false});
-
-  final IconData icon;
-  final String label;
-  final bool ellipsis;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.theme.colors;
-    final typography = context.theme.typography;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: 14, color: colors.mutedForeground),
-        const SizedBox(width: 4),
-        Flexible(
-          child: Text(
-            label,
-            style: typography.xs.copyWith(color: colors.mutedForeground),
-            overflow: ellipsis ? TextOverflow.ellipsis : TextOverflow.visible,
-            maxLines: 1,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _RemainingChip extends StatelessWidget {
-  const _RemainingChip({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.theme.colors;
-    final typography = context.theme.typography;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(FIcons.clock, size: 14, color: colors.primary),
-        const SizedBox(width: 4),
-        Text(label, style: typography.xs.copyWith(color: colors.primary, fontWeight: FontWeight.w600)),
-      ],
+    return FTile(
+      prefix: Icon(style.icon, color: current ? colors.primary : null),
+      title: Text(item.entry.title.isNotEmpty ? item.entry.title : style.label),
+      subtitle: subtitle.isEmpty ? null : Text(subtitle),
+      details: current ? Text(t.minutesLeft(item.remainingMinutesAt(now))) : null,
     );
   }
 }

--- a/lib/ui/timetable/timeline_row.dart
+++ b/lib/ui/timetable/timeline_row.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
-import 'package:schuly_api/schuly_api.dart';
-
-import '../../l10n/app_localizations.dart';
 import 'break_card.dart';
 import 'day_schedule.dart';
-import 'entry_style.dart';
+import 'lesson_tile.dart';
 
 class TimelineRow extends StatelessWidget {
   const TimelineRow({super.key, required this.item, required this.now, required this.isLast});
@@ -52,69 +49,11 @@ class TimelineRow extends StatelessWidget {
                       border: Border(bottom: BorderSide(color: colors.border.withValues(alpha: 0.4))),
                     ),
               child: switch (item) {
-                LessonItem lesson => _LessonContent(lesson: lesson, now: now),
-                BreakItem brk => BreakCard(item: brk, now: now),
+                LessonItem lesson => LessonTile(item: lesson, now: now, showTime: false),
+                BreakItem brk => BreakCard(item: brk, now: now, showTime: false),
               },
             ),
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LessonContent extends StatelessWidget {
-  const _LessonContent({required this.lesson, required this.now});
-
-  final LessonItem lesson;
-  final DateTime now;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.theme.colors;
-    final typography = context.theme.typography;
-    final t = AppLocalizations.of(context)!;
-    final style = entryStyle(context, lesson.entry.entryType);
-    final current = lesson.isCurrentAt(now);
-    final borderColor = current ? colors.primary : colors.border;
-
-    final subtitle = [lesson.entry.place, lesson.entry.description]
-        .where((s) => s != null && s.isNotEmpty)
-        .join(' - ');
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: borderColor, width: current ? 1.5 : 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(lesson.entry.title,
-                    style: typography.sm.copyWith(fontWeight: FontWeight.w600),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis),
-              ),
-              if (lesson.entry.entryType != AgendaEntryType.lesson) ...[
-                const SizedBox(width: 6),
-                EntryTypeBadge(label: style.label, color: style.color),
-              ],
-            ],
-          ),
-          if (subtitle.isNotEmpty || current) ...[
-            const SizedBox(height: 2),
-            Text(
-              [
-                if (subtitle.isNotEmpty) subtitle,
-                if (current) t.minutesLeft(lesson.remainingMinutesAt(now)),
-              ].join(' · '),
-              style: typography.xs.copyWith(color: colors.mutedForeground),
-            ),
-          ],
         ],
       ),
     );

--- a/lib/ui/timetable/timeline_row.dart
+++ b/lib/ui/timetable/timeline_row.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../l10n/app_localizations.dart';
+import 'break_card.dart';
+import 'day_schedule.dart';
+import 'entry_style.dart';
+
+class TimelineRow extends StatelessWidget {
+  const TimelineRow({super.key, required this.item, required this.now, required this.isLast});
+
+  final DayItem item;
+  final DateTime now;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final dayItem = item;
+    final showEndTime = dayItem is! LessonItem || dayItem.hasEndTime;
+
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 68,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8, bottom: 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(formatHm(item.start),
+                      style: typography.xs.copyWith(fontWeight: FontWeight.w600)),
+                  if (showEndTime)
+                    Text(formatHm(item.end),
+                        style: typography.xs.copyWith(color: colors.mutedForeground)),
+                ],
+              ),
+            ),
+          ),
+          Container(width: 1, color: colors.border),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              decoration: isLast
+                  ? null
+                  : BoxDecoration(
+                      border: Border(bottom: BorderSide(color: colors.border.withValues(alpha: 0.4))),
+                    ),
+              child: switch (item) {
+                LessonItem lesson => _LessonContent(lesson: lesson, now: now),
+                BreakItem brk => BreakCard(item: brk, now: now),
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LessonContent extends StatelessWidget {
+  const _LessonContent({required this.lesson, required this.now});
+
+  final LessonItem lesson;
+  final DateTime now;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final t = AppLocalizations.of(context)!;
+    final style = entryStyle(context, lesson.entry.entryType);
+    final current = lesson.isCurrentAt(now);
+    final borderColor = current ? style.color : style.color.withValues(alpha: 0.4);
+
+    final subtitle = [lesson.entry.place, lesson.entry.description]
+        .where((s) => s != null && s.isNotEmpty)
+        .join(' - ');
+
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: colors.secondary,
+        borderRadius: BorderRadius.circular(6),
+        border: Border(left: BorderSide(color: borderColor, width: 3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(lesson.entry.title,
+                    style: typography.sm.copyWith(fontWeight: FontWeight.w600),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis),
+              ),
+              if (lesson.entry.entryType != AgendaEntryType.lesson) ...[
+                const SizedBox(width: 6),
+                EntryTypeBadge(label: style.label, color: style.color),
+              ],
+            ],
+          ),
+          if (subtitle.isNotEmpty || current) ...[
+            const SizedBox(height: 2),
+            Text(
+              [
+                if (subtitle.isNotEmpty) subtitle,
+                if (current) t.minutesLeft(lesson.remainingMinutesAt(now)),
+              ].join(' · '),
+              style: typography.xs.copyWith(color: colors.mutedForeground),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/timetable/timeline_row.dart
+++ b/lib/ui/timetable/timeline_row.dart
@@ -18,44 +18,41 @@ class TimelineRow extends StatelessWidget {
     final dayItem = item;
     final showEndTime = dayItem is! LessonItem || dayItem.hasEndTime;
 
-    return IntrinsicHeight(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 68,
-            child: Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(formatHm(item.start),
-                      style: typography.xs.copyWith(fontWeight: FontWeight.w600)),
-                  if (showEndTime)
-                    Text(formatHm(item.end),
-                        style: typography.xs.copyWith(color: colors.mutedForeground)),
-                ],
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 68,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 8, bottom: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(formatHm(item.start),
+                    style: typography.xs.copyWith(fontWeight: FontWeight.w600)),
+                if (showEndTime)
+                  Text(formatHm(item.end),
+                      style: typography.xs.copyWith(color: colors.mutedForeground)),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.only(left: 12, top: 8, bottom: 8),
+            decoration: BoxDecoration(
+              border: Border(
+                left: BorderSide(color: colors.border),
+                bottom: isLast ? BorderSide.none : BorderSide(color: colors.border.withValues(alpha: 0.4)),
               ),
             ),
+            child: switch (item) {
+              LessonItem lesson => LessonTile(item: lesson, now: now, showTime: false),
+              BreakItem brk => BreakCard(item: brk, now: now, showTime: false),
+            },
           ),
-          FDivider(axis: Axis.vertical, style: (s) => s.copyWith(color: colors.border, padding: EdgeInsets.zero)),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              decoration: isLast
-                  ? null
-                  : BoxDecoration(
-                      border: Border(bottom: BorderSide(color: colors.border.withValues(alpha: 0.4))),
-                    ),
-              child: switch (item) {
-                LessonItem lesson => LessonTile(item: lesson, now: now, showTime: false),
-                BreakItem brk => BreakCard(item: brk, now: now, showTime: false),
-              },
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/timetable/timeline_row.dart
+++ b/lib/ui/timetable/timeline_row.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 import 'break_card.dart';
 import 'day_schedule.dart';
@@ -38,7 +38,7 @@ class TimelineRow extends StatelessWidget {
               ),
             ),
           ),
-          Container(width: 1, color: colors.border),
+          FDivider(axis: Axis.vertical, style: (s) => s.copyWith(color: colors.border, padding: EdgeInsets.zero)),
           const SizedBox(width: 12),
           Expanded(
             child: Container(

--- a/lib/ui/timetable/timeline_row.dart
+++ b/lib/ui/timetable/timeline_row.dart
@@ -76,18 +76,17 @@ class _LessonContent extends StatelessWidget {
     final t = AppLocalizations.of(context)!;
     final style = entryStyle(context, lesson.entry.entryType);
     final current = lesson.isCurrentAt(now);
-    final borderColor = current ? style.color : style.color.withValues(alpha: 0.4);
+    final borderColor = current ? colors.primary : colors.border;
 
     final subtitle = [lesson.entry.place, lesson.entry.description]
         .where((s) => s != null && s.isNotEmpty)
         .join(' - ');
 
     return Container(
-      padding: const EdgeInsets.all(10),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
-        color: colors.secondary,
-        borderRadius: BorderRadius.circular(6),
-        border: Border(left: BorderSide(color: borderColor, width: 3)),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor, width: current ? 1.5 : 1),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/ui/timetable/timetable_page.dart
+++ b/lib/ui/timetable/timetable_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
-import 'package:schuly_api/schuly_api.dart';
 
+import '../../l10n/app_localizations.dart';
 import '../../services/school_data_service.dart';
+import '../core/ui/now_ticker.dart';
+import 'day_schedule.dart';
+import 'timeline_row.dart';
 
 class TimetablePage extends StatefulWidget {
   const TimetablePage({super.key});
@@ -38,7 +41,7 @@ class _TimetablePageState extends State<TimetablePage> {
 
   static DateTime? _nearestEntryDay(List<dynamic> agenda, DateTime today) {
     final days = <DateTime>{
-      for (final a in agenda) DateTime(a.date.year, a.date.month, a.date.day),
+      for (final a in agenda) _localDay(a.date),
     }.toList()
       ..sort();
     if (days.isEmpty) return null;
@@ -48,18 +51,26 @@ class _TimetablePageState extends State<TimetablePage> {
     return days.last; // everything is in the past → most recent
   }
 
+  static DateTime _localDay(DateTime d) {
+    final local = d.toLocal();
+    return DateTime(local.year, local.month, local.day);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
+    final t = AppLocalizations.of(context)!;
     final svc = SchoolDataService.instance;
     final now = DateTime.now();
     final selected = _selected ?? DateTime(now.year, now.month, now.day);
 
-    bool sameDay(DateTime d) =>
-        d.year == selected.year && d.month == selected.month && d.day == selected.day;
+    bool sameDay(DateTime d) {
+      final local = d.toLocal();
+      return local.year == selected.year && local.month == selected.month && local.day == selected.day;
+    }
 
     final entries = svc.agenda.where((a) => sameDay(a.date)).toList()
-      ..sort((a, b) => a.date.compareTo(b.date));
+      ..sort((a, b) => a.date.toLocal().compareTo(b.date.toLocal()));
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -95,81 +106,28 @@ class _TimetablePageState extends State<TimetablePage> {
                       SizedBox(
                         height: 320,
                         child: Center(
-                          child: Text('Nothing scheduled',
+                          child: Text(t.nothingScheduled,
                               style: TextStyle(color: colors.mutedForeground)),
                         ),
                       ),
                     ],
                   )
-                : ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                    children: [
-                      for (final e in entries)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: _EntryTile(entry: e),
-                        ),
-                    ],
+                : NowTicker(
+                    builder: (context, now) {
+                      final items = buildDaySchedule(entries);
+                      return ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                        children: [
+                          for (var i = 0; i < items.length; i++)
+                            TimelineRow(item: items[i], now: now, isLast: i == items.length - 1),
+                        ],
+                      );
+                    },
                   ),
           ),
         ),
       ],
     );
   }
-}
-
-class _EntryTile extends StatelessWidget {
-  final AgendaEntryDto entry;
-  const _EntryTile({required this.entry});
-
-  @override
-  Widget build(BuildContext context) {
-    final (label, color, icon) = _typeMeta(context, entry.entryType);
-    final time = _timeRange(entry.date);
-    return FTile(
-      prefix: Icon(icon, color: color),
-      title: Text(entry.title.isNotEmpty == true ? entry.title : label),
-      subtitle: Text([time, entry.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
-      suffix: _TypeBadge(label: label, color: color),
-    );
-  }
-
-  static String _timeRange(DateTime d) {
-    final h = d.hour.toString().padLeft(2, '0');
-    final m = d.minute.toString().padLeft(2, '0');
-    return '$h:$m';
-  }
-
-  static (String, Color, IconData) _typeMeta(BuildContext context, AgendaEntryType? t) {
-    final colors = context.theme.colors;
-    switch (t) {
-      case AgendaEntryType.test:
-        return ('Test', const Color(0xFFEF4444), FIcons.clipboardList);
-      case AgendaEntryType.event:
-        return ('Event', const Color(0xFF22C55E), FIcons.calendarHeart);
-      case AgendaEntryType.holiday:
-        return ('Holiday', const Color(0xFFF59E0B), FIcons.treePalm);
-      case AgendaEntryType.lesson:
-      default:
-        return ('Lesson', colors.primary, FIcons.bookOpen);
-    }
-  }
-}
-
-class _TypeBadge extends StatelessWidget {
-  final String label;
-  final Color color;
-  const _TypeBadge({required this.label, required this.color});
-
-  @override
-  Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.16),
-          borderRadius: BorderRadius.circular(6),
-        ),
-        child: Text(label,
-            style: TextStyle(color: color, fontWeight: FontWeight.w600, fontSize: 12)),
-      );
 }

--- a/test/break_card_test.dart
+++ b/test/break_card_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly/l10n/app_localizations.dart';
+import 'package:schuly/ui/timetable/break_card.dart';
+import 'package:schuly/ui/timetable/day_schedule.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        ...AppLocalizations.localizationsDelegates,
+        ...FLocalizations.localizationsDelegates,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: FTheme(data: FThemes.zinc.light, child: Scaffold(body: child)),
+    );
+
+void main() {
+  testWidgets('a 15-minute break renders the Break (15 min) text', (tester) async {
+    final item = BreakItem(start: DateTime(2026, 1, 5, 9), end: DateTime(2026, 1, 5, 9, 15));
+    await tester.pumpWidget(_wrap(BreakCard(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('Break (15 min)'), findsOneWidget);
+  });
+
+  testWidgets('a 45-minute lunch break renders the Lunch break (45 min) text', (tester) async {
+    final item = BreakItem(start: DateTime(2026, 1, 5, 11, 45), end: DateTime(2026, 1, 5, 12, 30));
+    await tester.pumpWidget(_wrap(BreakCard(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('Lunch break (45 min)'), findsOneWidget);
+  });
+
+  testWidgets('a current break renders the min-left text', (tester) async {
+    final item = BreakItem(start: DateTime(2026, 1, 5, 9), end: DateTime(2026, 1, 5, 9, 15));
+    await tester.pumpWidget(_wrap(BreakCard(item: item, now: DateTime(2026, 1, 5, 9, 5))));
+
+    expect(find.textContaining('min left'), findsOneWidget);
+  });
+
+  testWidgets('a non-current break does not render the min-left text', (tester) async {
+    final item = BreakItem(start: DateTime(2026, 1, 5, 9), end: DateTime(2026, 1, 5, 9, 15));
+    await tester.pumpWidget(_wrap(BreakCard(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('min left'), findsNothing);
+  });
+}

--- a/test/break_card_test.dart
+++ b/test/break_card_test.dart
@@ -43,4 +43,15 @@ void main() {
 
     expect(find.textContaining('min left'), findsNothing);
   });
+
+  testWidgets('a current break in a narrow timeline tile still shows the full min-left text', (tester) async {
+    final item = BreakItem(start: DateTime(2026, 1, 5, 9), end: DateTime(2026, 1, 5, 9, 15));
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 260,
+      child: BreakCard(item: item, now: DateTime(2026, 1, 5, 9, 9), showTime: false),
+    )));
+
+    expect(find.textContaining('6 min left'), findsOneWidget);
+    expect(find.textContaining('...'), findsNothing);
+  });
 }

--- a/test/day_schedule_test.dart
+++ b/test/day_schedule_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/ui/timetable/day_schedule.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+AgendaEntryDto _entry({
+  required DateTime date,
+  DateTime? endDate,
+  String title = 'Math',
+  AgendaEntryType type = AgendaEntryType.lesson,
+}) {
+  return AgendaEntryDto((b) => b
+    ..entryType = type
+    ..title = title
+    ..date = date
+    ..endDate = endDate);
+}
+
+void main() {
+  group('buildDaySchedule breaks', () {
+    test('no break for a 4-minute gap', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 8, 49));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), isEmpty);
+    });
+
+    test('break for exactly a 5-minute gap', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 8, 50));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), hasLength(1));
+      expect(items.whereType<BreakItem>().first.minutes, 5);
+    });
+
+    test('break for a mid-value gap (15 minutes)', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 9));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), hasLength(1));
+      expect(items.whereType<BreakItem>().first.minutes, 15);
+    });
+
+    test('the break lands between the two lessons in the returned order', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 9));
+      final items = buildDaySchedule([a, b]);
+      expect(items, [isA<LessonItem>(), isA<BreakItem>(), isA<LessonItem>()]);
+      final firstLesson = items[0] as LessonItem;
+      final gapBreak = items[1] as BreakItem;
+      final secondLesson = items[2] as LessonItem;
+      expect(gapBreak.start, firstLesson.end);
+      expect(gapBreak.end, secondLesson.start);
+    });
+
+    test('break for exactly a 120-minute gap', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 10, 45));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), hasLength(1));
+      expect(items.whereType<BreakItem>().first.minutes, 120);
+    });
+
+    test('no break for a 121-minute gap', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 10, 46));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), isEmpty);
+    });
+
+    test('no break for a zero/negative gap (overlapping entries)', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 9));
+      final b = _entry(date: DateTime(2026, 1, 5, 8, 30));
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), isEmpty);
+    });
+
+    test('withBreaks: false yields no breaks', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+      final b = _entry(date: DateTime(2026, 1, 5, 9));
+      final items = buildDaySchedule([a, b], withBreaks: false);
+      expect(items.whereType<BreakItem>(), isEmpty);
+      expect(items, hasLength(2));
+    });
+  });
+
+  group('buildDaySchedule ordering', () {
+    test('entries are sorted by start regardless of input order', () {
+      final early = _entry(date: DateTime(2026, 1, 5, 8), title: 'Early');
+      final late = _entry(date: DateTime(2026, 1, 5, 10), title: 'Late');
+      final mid = _entry(date: DateTime(2026, 1, 5, 9), title: 'Mid');
+      final items = buildDaySchedule([late, early, mid], withBreaks: false).cast<LessonItem>();
+      expect(items.map((i) => i.entry.title).toList(), ['Early', 'Mid', 'Late']);
+    });
+
+    test('does not mutate the caller-supplied list', () {
+      final early = _entry(date: DateTime(2026, 1, 5, 8), title: 'Early');
+      final late = _entry(date: DateTime(2026, 1, 5, 10), title: 'Late');
+      final input = [late, early];
+      buildDaySchedule(input);
+      expect(input[0].title, 'Late');
+      expect(input[1].title, 'Early');
+    });
+  });
+
+  group('fallback lesson duration', () {
+    test('an entry without endDate has hasEndTime false and a 45-minute fallback end', () {
+      final start = DateTime(2026, 1, 5, 8);
+      final entry = _entry(date: start);
+      final item = LessonItem(entry);
+      expect(item.hasEndTime, isFalse);
+      expect(item.end, start.add(kFallbackLessonDuration));
+    });
+
+    test('the gap to the next entry is measured from the fallback end', () {
+      final a = _entry(date: DateTime(2026, 1, 5, 8)); // no endDate -> ends 08:45
+      final b = _entry(date: DateTime(2026, 1, 5, 9)); // gap of exactly 15 minutes from fallback end
+      final items = buildDaySchedule([a, b]);
+      expect(items.whereType<BreakItem>(), hasLength(1));
+      expect(items.whereType<BreakItem>().first.minutes, 15);
+    });
+  });
+
+  group('current-lesson detection', () {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+    final item = LessonItem(entry);
+
+    test('isCurrentAt is true at exactly start', () {
+      expect(item.isCurrentAt(item.start), isTrue);
+    });
+
+    test('isCurrentAt is true mid-lesson', () {
+      expect(item.isCurrentAt(item.start.add(const Duration(minutes: 20))), isTrue);
+    });
+
+    test('isCurrentAt is false at exactly end', () {
+      expect(item.isCurrentAt(item.end), isFalse);
+    });
+
+    test('isCurrentAt is false before start', () {
+      expect(item.isCurrentAt(item.start.subtract(const Duration(minutes: 1))), isFalse);
+    });
+
+    test('isCurrentAt is false after end', () {
+      expect(item.isCurrentAt(item.end.add(const Duration(minutes: 1))), isFalse);
+    });
+
+    test('currentItem picks the right item', () {
+      final other = _entry(date: DateTime(2026, 1, 5, 9), endDate: DateTime(2026, 1, 5, 9, 45));
+      final items = buildDaySchedule([entry, other], withBreaks: false);
+      final now = DateTime(2026, 1, 5, 9, 10);
+      final current = currentItem(items, now);
+      expect(current, isA<LessonItem>());
+      expect((current as LessonItem).entry.date, other.date);
+    });
+
+    test('currentItem returns null when nothing is current', () {
+      final items = buildDaySchedule([entry], withBreaks: false);
+      final now = DateTime(2026, 1, 5, 12);
+      expect(currentItem(items, now), isNull);
+    });
+  });
+
+  group('lunch detection', () {
+    test('a 45-minute 11:45-12:30 break is lunch', () {
+      final b = BreakItem(start: DateTime(2026, 1, 5, 11, 45), end: DateTime(2026, 1, 5, 12, 30));
+      expect(b.isLunch, isTrue);
+    });
+
+    test('a 15-minute 11:45-12:00 break is not lunch (too short)', () {
+      final b = BreakItem(start: DateTime(2026, 1, 5, 11, 45), end: DateTime(2026, 1, 5, 12, 0));
+      expect(b.isLunch, isFalse);
+    });
+
+    test('a 45-minute 09:00-09:45 break is not lunch (outside window)', () {
+      final b = BreakItem(start: DateTime(2026, 1, 5, 9), end: DateTime(2026, 1, 5, 9, 45));
+      expect(b.isLunch, isFalse);
+    });
+
+    test('a break ending after 13:30 is not lunch', () {
+      final b = BreakItem(start: DateTime(2026, 1, 5, 12, 50), end: DateTime(2026, 1, 5, 13, 35));
+      expect(b.isLunch, isFalse);
+    });
+  });
+
+  group('toLocal handling', () {
+    test('a UTC DateTime produces a local, non-UTC start at the expected instant', () {
+      final utc = DateTime.utc(2026, 1, 5, 8);
+      final entry = _entry(date: utc);
+      final item = LessonItem(entry);
+      expect(item.start.isUtc, isFalse);
+      expect(item.start, utc.toLocal());
+    });
+  });
+}

--- a/test/day_schedule_test.dart
+++ b/test/day_schedule_test.dart
@@ -191,4 +191,26 @@ void main() {
       expect(item.start, utc.toLocal());
     });
   });
+
+  group('stripShortCode', () {
+    test('strips a trailing 4-letter short code', () {
+      expect(stripShortCode('Bachofner Manuel (BaMa)'), 'Bachofner Manuel');
+    });
+
+    test('strips a different trailing short code', () {
+      expect(stripShortCode('Moor Andy (MoAn)'), 'Moor Andy');
+    });
+
+    test('leaves a parenthesised phrase that is not a short code untouched', () {
+      expect(stripShortCode('Excursion (bring lunch)'), 'Excursion (bring lunch)');
+    });
+
+    test('leaves a plain string untouched', () {
+      expect(stripShortCode('Sport'), 'Sport');
+    });
+
+    test('leaves an empty string untouched', () {
+      expect(stripShortCode(''), '');
+    });
+  });
 }

--- a/test/lesson_tile_test.dart
+++ b/test/lesson_tile_test.dart
@@ -58,4 +58,16 @@ void main() {
 
     expect(find.textContaining('min left'), findsNothing);
   });
+
+  testWidgets('a current lesson in a narrow timeline tile still shows the full min-left text', (tester) async {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+    final item = LessonItem(entry);
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 260,
+      child: LessonTile(item: item, now: DateTime(2026, 1, 5, 8, 39), showTime: false),
+    )));
+
+    expect(find.textContaining('6 min left'), findsOneWidget);
+    expect(find.textContaining('...'), findsNothing);
+  });
 }

--- a/test/lesson_tile_test.dart
+++ b/test/lesson_tile_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly/l10n/app_localizations.dart';
+import 'package:schuly/ui/timetable/day_schedule.dart';
+import 'package:schuly/ui/timetable/lesson_tile.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+AgendaEntryDto _entry({required DateTime date, DateTime? endDate, String title = 'Math'}) {
+  return AgendaEntryDto((b) => b
+    ..entryType = AgendaEntryType.lesson
+    ..title = title
+    ..date = date
+    ..endDate = endDate);
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        ...AppLocalizations.localizationsDelegates,
+        ...FLocalizations.localizationsDelegates,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: FTheme(data: FThemes.zinc.light, child: Scaffold(body: child)),
+    );
+
+void main() {
+  testWidgets('a lesson with an endDate renders both the from and until times', (tester) async {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+    final item = LessonItem(entry);
+    await tester.pumpWidget(_wrap(LessonTile(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('08:00'), findsOneWidget);
+    expect(find.textContaining('08:45'), findsOneWidget);
+  });
+
+  testWidgets('a lesson without an endDate renders the start time but no until time', (tester) async {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8));
+    final item = LessonItem(entry);
+    await tester.pumpWidget(_wrap(LessonTile(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('08:00'), findsOneWidget);
+    expect(find.textContaining('08:45'), findsNothing);
+  });
+
+  testWidgets('a current lesson renders the min-left text', (tester) async {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+    final item = LessonItem(entry);
+    await tester.pumpWidget(_wrap(LessonTile(item: item, now: DateTime(2026, 1, 5, 8, 30))));
+
+    expect(find.textContaining('min left'), findsOneWidget);
+  });
+
+  testWidgets('a non-current lesson does not render the min-left text', (tester) async {
+    final entry = _entry(date: DateTime(2026, 1, 5, 8), endDate: DateTime(2026, 1, 5, 8, 45));
+    final item = LessonItem(entry);
+    await tester.pumpWidget(_wrap(LessonTile(item: item, now: DateTime(2026, 1, 5, 7))));
+
+    expect(find.textContaining('min left'), findsNothing);
+  });
+}

--- a/test/now_ticker_test.dart
+++ b/test/now_ticker_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/ui/core/ui/now_ticker.dart';
+
+void main() {
+  testWidgets('now stays stale across an app resume without the resume-refresh fix path', (tester) async {
+    // A long interval so the periodic timer has no chance to fire during the
+    // test - only an explicit resume should be able to refresh `now`.
+    final calls = <DateTime>[];
+    await tester.pumpWidget(MaterialApp(
+      home: NowTicker(
+        interval: const Duration(minutes: 30),
+        builder: (context, now) {
+          calls.add(now);
+          return const SizedBox();
+        },
+      ),
+    ));
+
+    expect(calls, hasLength(1));
+
+    // Simulate the device being backgrounded for a while (its background
+    // timers are commonly suspended by the OS) and then resumed.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    // A resume must trigger an immediate rebuild with a fresh `now`, not wait
+    // for the next 30-minute tick - this is what made the home page miss a
+    // lesson that was already running by the time the app was reopened.
+    expect(calls.length, greaterThan(1));
+  });
+
+  testWidgets('the periodic tick still refreshes now on its own', (tester) async {
+    final calls = <DateTime>[];
+    await tester.pumpWidget(MaterialApp(
+      home: NowTicker(
+        interval: const Duration(seconds: 30),
+        builder: (context, now) {
+          calls.add(now);
+          return const SizedBox();
+        },
+      ),
+    ));
+
+    expect(calls, hasLength(1));
+    await tester.pump(const Duration(seconds: 31));
+    expect(calls.length, greaterThan(1));
+  });
+}


### PR DESCRIPTION
## Summary

- Ported the legacy lesson tile: a from/until time block next to subject, room and details, with a coloured left border per entry type and a full-opacity border plus remaining-minutes chip while the lesson is running.
- Added break cards between consecutive entries when the gap is 5-120 minutes, with a coffee icon, or a utensils icon and a lunch label inside the 11:00-13:30 window from 30 minutes, highlighted while current.
- Added `buildDaySchedule`, a pure helper that sorts a day's agenda entries and interleaves the break items, plus half-open `[start, end)` current-item detection.
- Added `NowTicker`, a small widget that rebuilds its subtree every 30 seconds and disposes its timer, so the current-lesson highlight moves on its own.
- Rebuilt the timetable page as a timeline: a left time column with start over end, a vertical divider and compact per-type coloured cards.
- Read DTO times through `.toLocal()` everywhere before comparing or formatting, and treat a missing `endDate` as start plus 45 minutes for layout only.
- Moved the new strings into the l10n arb files for de and en.

Closes #489
