### PR TITLE
Add data export and account deletion to settings

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -6,5 +6,19 @@
   "tabGrades": "Noten",
   "tabAbsences": "Absenzen",
   "tabAccount": "Konto",
-  "signIn": "Anmelden"
+  "signIn": "Anmelden",
+  "privacySectionLabel": "Datenschutz",
+  "exportDataTitle": "Meine Daten exportieren",
+  "exportDataSubtitle": "Als JSON-Datei herunterladen",
+  "exportDataFailed": "Export fehlgeschlagen",
+  "deleteAccountTitle": "Konto löschen",
+  "deleteAccountSubtitle": "Konto und Daten dauerhaft löschen",
+  "deleteAccountFailed": "Löschen fehlgeschlagen",
+  "deleteAccountDialogTitle": "Konto löschen?",
+  "deleteAccountDialogBody": "Dies löscht dein Konto und alle Daten auf dem Server dauerhaft. Dies kann nicht rückgängig gemacht werden.",
+  "deleteAccountConfirmLabel": "Gib DELETE ein, um zu bestätigen",
+  "deleteAccountCancel": "Abbrechen",
+  "deleteAccountConfirm": "Konto löschen",
+  "privacyPrivateModeTitle": "Nichts wird auf unseren Servern gespeichert",
+  "privacyPrivateModeSubtitle": "Der private Modus speichert deine Daten nur auf diesem Gerät. Verwende „Abmelden“, um die Verbindung zu trennen und die Daten zu entfernen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9,5 +9,61 @@
   "tabGrades": "Grades",
   "tabAbsences": "Absences",
   "tabAccount": "Account",
-  "signIn": "Sign in"
+  "signIn": "Sign in",
+  "privacySectionLabel": "Privacy",
+  "@privacySectionLabel": {
+    "description": "Settings section label for data export / account deletion"
+  },
+  "exportDataTitle": "Export my data",
+  "@exportDataTitle": {
+    "description": "Settings tile title to download an account data export"
+  },
+  "exportDataSubtitle": "Download a copy as JSON",
+  "@exportDataSubtitle": {
+    "description": "Settings tile subtitle for the data export action"
+  },
+  "exportDataFailed": "Export failed",
+  "@exportDataFailed": {
+    "description": "Toast title when the data export request fails"
+  },
+  "deleteAccountTitle": "Delete account",
+  "@deleteAccountTitle": {
+    "description": "Settings tile title to delete the account"
+  },
+  "deleteAccountSubtitle": "Permanently delete your account and data",
+  "@deleteAccountSubtitle": {
+    "description": "Settings tile subtitle for the account deletion action"
+  },
+  "deleteAccountFailed": "Delete failed",
+  "@deleteAccountFailed": {
+    "description": "Toast title when the account deletion request fails"
+  },
+  "deleteAccountDialogTitle": "Delete account?",
+  "@deleteAccountDialogTitle": {
+    "description": "Title of the account deletion confirmation dialog"
+  },
+  "deleteAccountDialogBody": "This permanently deletes your account and all data on the server. This can't be undone.",
+  "@deleteAccountDialogBody": {
+    "description": "Body text of the account deletion confirmation dialog"
+  },
+  "deleteAccountConfirmLabel": "Type DELETE to confirm",
+  "@deleteAccountConfirmLabel": {
+    "description": "Label for the text field that must contain DELETE to enable the destructive button"
+  },
+  "deleteAccountCancel": "Cancel",
+  "@deleteAccountCancel": {
+    "description": "Cancel button in the account deletion dialog"
+  },
+  "deleteAccountConfirm": "Delete account",
+  "@deleteAccountConfirm": {
+    "description": "Destructive confirm button in the account deletion dialog"
+  },
+  "privacyPrivateModeTitle": "Nothing stored on our servers",
+  "@privacyPrivateModeTitle": {
+    "description": "Explanatory tile title shown in private mode instead of export/delete"
+  },
+  "privacyPrivateModeSubtitle": "Private mode keeps your data on this device only. Use Sign out to disconnect and remove it.",
+  "@privacyPrivateModeSubtitle": {
+    "description": "Explanatory tile subtitle shown in private mode, pointing at the disconnect (sign out) action"
+  }
 }

--- a/lib/services/account_api.dart
+++ b/lib/services/account_api.dart
@@ -1,0 +1,26 @@
+import 'package:dio/dio.dart';
+
+import 'api_client.dart';
+
+/// Hand-written calls for the account deletion / data export endpoints
+/// (SchulyBackend#274) - not yet in the generated OpenAPI client. Move these
+/// onto `ApiClient.instance.api` once the backend PR merges and `bun run
+/// apigen` regenerates `lib/api/` from the live spec.
+class AccountApi {
+  AccountApi._();
+
+  /// `DELETE /api/auth/me` - permanently deletes the signed-in user's account
+  /// and server-side data. Resolves on `204 No Content`.
+  static Future<void> deleteAccount() {
+    return ApiClient.instance.dio.delete<void>('/api/auth/me', options: ApiClient.handled());
+  }
+
+  /// `GET /api/auth/me/export` - the account's data as a JSON attachment.
+  static Future<List<int>> exportData() async {
+    final res = await ApiClient.instance.dio.get<List<int>>(
+      '/api/auth/me/export',
+      options: ApiClient.handled(Options(responseType: ResponseType.bytes)),
+    );
+    return res.data ?? const [];
+  }
+}

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -7,9 +7,24 @@ import '../../../services/app_mode_service.dart';
 import '../../../services/auth_service.dart';
 import '../../../services/onboarding_service.dart';
 import '../../../services/private_account_store.dart';
+import '../../../services/school_data_service.dart';
 import '../../dashboard/dashboard_screen.dart';
 import '../../onboarding/onboarding_screen.dart';
 import '../../private/private_connect_flow.dart';
+
+/// Full sign-out: clears tokens, the active school, cached school data, and
+/// any on-disk private-mode credentials, then drops the app back to account
+/// mode. Shared by the sign-out action and account deletion.
+Future<void> signOutAndClear() async {
+  if (AppModeService.instance.isPrivate) {
+    await PrivateAccountStore.instance.clear();
+    await AppModeService.instance.setMode(AppMode.account);
+  } else {
+    await AuthService.signOut();
+    await ActiveAccountService.instance.clear();
+  }
+  SchoolDataService.instance.clear();
+}
 
 class RootScreen extends StatefulWidget {
   const RootScreen({super.key});
@@ -90,13 +105,7 @@ class _RootScreenState extends State<RootScreen> {
   }
 
   Future<void> _signOut() async {
-    if (AppModeService.instance.isPrivate) {
-      await PrivateAccountStore.instance.clear();
-      await AppModeService.instance.setMode(AppMode.account);
-    } else {
-      await AuthService.signOut();
-      await ActiveAccountService.instance.clear();
-    }
+    await signOutAndClear();
     await _refresh();
   }
 

--- a/lib/ui/settings/privacy_settings_section.dart
+++ b/lib/ui/settings/privacy_settings_section.dart
@@ -1,0 +1,171 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../services/account_api.dart';
+import '../../services/app_mode_service.dart';
+import '../../services/toast_service.dart';
+import '../core/ui/root_screen.dart';
+
+/// Settings section for exporting or permanently deleting the account's
+/// server-side data. In private mode nothing is ever stored server-side, so
+/// this renders a single explanatory tile pointing at the sign-out
+/// (disconnect) action instead.
+class PrivacySettingsSection extends StatefulWidget {
+  const PrivacySettingsSection({super.key});
+
+  @override
+  State<PrivacySettingsSection> createState() => _PrivacySettingsSectionState();
+}
+
+class _PrivacySettingsSectionState extends State<PrivacySettingsSection> {
+  bool _exporting = false;
+
+  static String _stamp(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}${d.month.toString().padLeft(2, '0')}${d.day.toString().padLeft(2, '0')}';
+
+  Future<void> _export() async {
+    if (_exporting) return;
+    setState(() => _exporting = true);
+    try {
+      final bytes = await AccountApi.exportData();
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/schuly-export-${_stamp(DateTime.now())}.json');
+      await file.writeAsBytes(bytes);
+      await SharePlus.instance.share(ShareParams(files: [XFile(file.path)]));
+    } catch (e) {
+      if (mounted) ToastService.error(AppLocalizations.of(context)!.exportDataFailed, e);
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
+  Future<void> _delete() async {
+    final confirmed = await showFDialog<bool>(
+      context: context,
+      builder: (ctx, style, animation) => _DeleteAccountDialog(animation: animation),
+    );
+    if (confirmed != true || !mounted) return;
+    try {
+      await AccountApi.deleteAccount();
+      await signOutAndClear();
+      if (mounted) Navigator.of(context).popUntil((route) => route.isFirst);
+    } catch (e) {
+      if (mounted) ToastService.error(AppLocalizations.of(context)!.deleteAccountFailed, e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final t = AppLocalizations.of(context)!;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+            child: Text(
+              t.privacySectionLabel.toUpperCase(),
+              style: typography.xs.copyWith(
+                color: colors.mutedForeground,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          if (AppModeService.instance.isPrivate)
+            FTile(
+              prefix: const Icon(FIcons.shieldCheck),
+              title: Text(t.privacyPrivateModeTitle),
+              subtitle: Text(t.privacyPrivateModeSubtitle),
+            )
+          else ...[
+            FTile(
+              prefix: const Icon(FIcons.download),
+              title: Text(t.exportDataTitle),
+              subtitle: Text(t.exportDataSubtitle),
+              suffix: _exporting ? const FCircularProgress() : null,
+              onPress: _exporting ? null : _export,
+            ),
+            const SizedBox(height: 8),
+            FTile(
+              prefix: Icon(FIcons.trash2, color: colors.destructive),
+              title: Text(t.deleteAccountTitle, style: TextStyle(color: colors.destructive)),
+              subtitle: Text(t.deleteAccountSubtitle),
+              onPress: _delete,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _DeleteAccountDialog extends StatefulWidget {
+  final Animation<double> animation;
+  const _DeleteAccountDialog({required this.animation});
+
+  @override
+  State<_DeleteAccountDialog> createState() => _DeleteAccountDialogState();
+}
+
+class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
+  late final _ctrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    final confirmed = _ctrl.text.trim() == 'DELETE';
+
+    return FDialog(
+      animation: widget.animation,
+      title: Text(t.deleteAccountDialogTitle),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(t.deleteAccountDialogBody),
+          const SizedBox(height: 12),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _ctrl),
+            label: Text(t.deleteAccountConfirmLabel),
+            hint: 'DELETE',
+            autocorrect: false,
+          ),
+        ],
+      ),
+      actions: [
+        FButton(
+          style: FButtonStyle.outline(),
+          onPress: () => Navigator.of(context).pop(false),
+          child: Text(t.deleteAccountCancel),
+        ),
+        FButton(
+          style: FButtonStyle.destructive(),
+          onPress: confirmed ? () => Navigator.of(context).pop(true) : null,
+          child: Text(t.deleteAccountConfirm),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -11,6 +11,7 @@ import '../../services/auth_service.dart';
 import '../../services/private_account_store.dart';
 import '../../services/school_data_service.dart';
 import '../../services/theme_service.dart';
+import 'privacy_settings_section.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -89,6 +90,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ],
           ),
           const SizedBox(height: 20),
+          const PrivacySettingsSection(),
           FTileGroup(
             label: const Text('About'),
             children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+5"
   crypto:
     dependency: "direct main"
     description:
@@ -628,6 +636,22 @@ packages:
       relative: true
     source: path
     version: "1.0.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -825,6 +849,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   forui_assets: ^0.17.1
   path_provider: ^2.1.2
   open_filex: ^4.5.0
+  share_plus: ^12.0.1
   # On-device TOTP: generate the second factor from a vaulted seed.
   otp: ^3.1.4
   # QR scanning to capture the TOTP seed.

--- a/test/privacy_settings_section_test.dart
+++ b/test/privacy_settings_section_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forui/forui.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:schuly/l10n/app_localizations.dart';
+import 'package:schuly/services/app_mode_service.dart';
+import 'package:schuly/ui/settings/privacy_settings_section.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      ...AppLocalizations.localizationsDelegates,
+      ...FLocalizations.localizationsDelegates,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: FTheme(data: FThemes.zinc.light, child: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('account mode shows both the export and delete tiles', (tester) async {
+    await AppModeService.instance.setMode(AppMode.account);
+    await tester.pumpWidget(_wrap(const PrivacySettingsSection()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Export my data'), findsOneWidget);
+    expect(find.text('Delete account'), findsOneWidget);
+    expect(find.text('Nothing stored on our servers'), findsNothing);
+  });
+
+  testWidgets('private mode shows a single explanatory tile', (tester) async {
+    await AppModeService.instance.setMode(AppMode.private);
+    await tester.pumpWidget(_wrap(const PrivacySettingsSection()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Export my data'), findsNothing);
+    expect(find.text('Delete account'), findsNothing);
+    expect(find.text('Nothing stored on our servers'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

- Add `AccountApi.deleteAccount()` / `AccountApi.exportData()` (hand-written calls on the authenticated Dio, pending SchulyBackend#274's OpenAPI merge)
- Add a "Privacy" settings section with "Export my data" (saves a `schuly-export-<yyyyMMdd>.json` and opens the share sheet via `share_plus`) and "Delete account" (`FDialog` confirm requiring `DELETE` to be typed before the destructive action enables)
- Extract the sign-out/clear logic from `RootScreen` into a reusable `signOutAndClear()` used by both the sign-out button and successful account deletion
- Show a single explanatory tile instead in private mode, since nothing is ever stored server-side there
- Add EN/DE l10n strings and a widget test covering both modes

Closes #499
