### PR TITLE
Add PR CI workflow for analyze, test, and Android debug build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'android/**'
+              - 'pubspec.yaml'
+
+  test:
+    name: Analyze and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.44.x'
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
+
+  android-build:
+    name: Android Debug Build
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.44.x'
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build Android debug APK
+        run: flutter build apk --flavor dev --debug

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,9 @@ class SchulyApp extends StatelessWidget {
           ],
           supportedLocales: AppLocalizations.supportedLocales,
           themeMode: ThemeService.instance.mode,
+          // ignore: experimental_member_use
           theme: FThemes.zinc.light.toApproximateMaterialTheme(),
+          // ignore: experimental_member_use
           darkTheme: FThemes.zinc.dark.toApproximateMaterialTheme(),
           builder: (ctx, child) {
             final mode = ThemeService.instance.mode;


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running on pull requests and pushes to `main`
- `test` job runs `flutter pub get`, `flutter analyze`, and `flutter test`
- `android-build` job builds a dev-flavor debug APK, gated to only run when `android/**` or `pubspec.yaml` changed (via `dorny/paths-filter@v3`)

Closes #503