### PR TITLE
Keep scrollable screens clear of the system navigation bar

### DIFF
--- a/lib/ui/account/unified_connect_screen.dart
+++ b/lib/ui/account/unified_connect_screen.dart
@@ -83,6 +83,7 @@ class _UnifiedConnectScreenState extends State<UnifiedConnectScreen> {
         prefixes: [FHeaderAction.back(onPress: () => Navigator.of(context).pop())],
       ),
       child: SingleChildScrollView(
+        padding: EdgeInsets.only(bottom: MediaQuery.viewPaddingOf(context).bottom),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           spacing: 16,

--- a/lib/ui/authenticator/add_totp_screen.dart
+++ b/lib/ui/authenticator/add_totp_screen.dart
@@ -100,6 +100,7 @@ class _AddTotpScreenState extends State<AddTotpScreen> {
       ),
       child: LayoutBuilder(
         builder: (context, constraints) => SingleChildScrollView(
+          padding: EdgeInsets.only(bottom: MediaQuery.viewPaddingOf(context).bottom),
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: constraints.maxHeight),
             child: IntrinsicHeight(

--- a/lib/ui/authenticator/authenticator_vault_screen.dart
+++ b/lib/ui/authenticator/authenticator_vault_screen.dart
@@ -122,6 +122,7 @@ class _AuthenticatorVaultScreenState extends State<AuthenticatorVaultScreen> {
           : _rows.isEmpty
               ? _empty(context)
               : ListView.separated(
+                  padding: EdgeInsets.only(bottom: MediaQuery.viewPaddingOf(context).bottom),
                   itemCount: _rows.length,
                   separatorBuilder: (_, _) => const SizedBox(height: 12),
                   itemBuilder: (_, i) => _CodeCard(

--- a/lib/ui/classes/class_detail_screen.dart
+++ b/lib/ui/classes/class_detail_screen.dart
@@ -74,7 +74,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
         onRefresh: _load,
         child: ListView(
           physics: const AlwaysScrollableScrollPhysics(),
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 24 + MediaQuery.viewPaddingOf(context).bottom),
           children: [
             if ((c.description?.isNotEmpty ?? false))
               Padding(

--- a/lib/ui/documents/documents_page.dart
+++ b/lib/ui/documents/documents_page.dart
@@ -117,7 +117,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
         onRefresh: _refresh,
         child: ListView(
           physics: const AlwaysScrollableScrollPhysics(),
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 32 + MediaQuery.viewPaddingOf(context).bottom),
           children: [
             if (folders.isEmpty)
               Padding(

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -34,7 +34,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ],
       ),
       child: ListView(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        padding: EdgeInsets.fromLTRB(16, 8, 16, 24 + MediaQuery.viewPaddingOf(context).bottom),
         children: [
           if (!AppModeService.instance.isPrivate) ...[
             const _SectionLabel('Account'),


### PR DESCRIPTION
## Summary
- Settings: include the bottom system view padding in the `ListView`'s bottom padding so the last tile (Open-source licenses) is reachable.
- Documents, class detail: same fix for their `ListView`s.
- Unified connect and add-TOTP screens: add bottom view padding to their `SingleChildScrollView`s.
- Authenticator vault: add bottom view padding to its `ListView.separated`.

Closes #505
