### PR TITLE
Refresh avatar on resume after uploading a profile picture

### DIFF
--- a/lib/services/profile_refresh_requests.dart
+++ b/lib/services/profile_refresh_requests.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+
+/// A cross-screen flag set when the user has been sent to the external
+/// Keycloak avatar page (Settings -> Profile picture), so the dashboard
+/// knows to force a claims refresh - with cache-busting on the picture URL -
+/// the next time the app resumes, instead of waiting for the normal
+/// staleness window.
+class ProfileRefreshRequests {
+  ProfileRefreshRequests._();
+
+  static final ValueNotifier<bool> pending = ValueNotifier<bool>(false);
+
+  static void request() => pending.value = true;
+
+  static void clear() => pending.value = false;
+}

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -1,11 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:forui/forui.dart';
 
 import '../../services/active_account_service.dart';
+import '../../services/api_client.dart';
 import '../../services/app_mode_service.dart';
 import '../../services/auth_service.dart';
 import '../../services/private_account_store.dart';
+import '../../services/profile_refresh_requests.dart';
 import '../../services/school_data_service.dart';
 import '../absences/absences_page.dart';
 import '../account/account_page.dart';
@@ -24,16 +28,18 @@ class DashboardScreen extends StatefulWidget {
   State<DashboardScreen> createState() => _DashboardScreenState();
 }
 
-class _DashboardScreenState extends State<DashboardScreen> {
+class _DashboardScreenState extends State<DashboardScreen> with WidgetsBindingObserver {
   String? _pictureUrl;
   String? _userName;
   String? _userEmail;
   String? _privateTitle;
   int _index = 0;
+  DateTime? _lastClaimsRead;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     ActiveAccountService.instance.addListener(_onActiveChanged);
     TabRequests.pending.addListener(_onTabRequested);
     _onTabRequested();
@@ -42,9 +48,51 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     ActiveAccountService.instance.removeListener(_onActiveChanged);
     TabRequests.pending.removeListener(_onTabRequested);
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (AppModeService.instance.isPrivate) return;
+    final requested = ProfileRefreshRequests.pending.value;
+    final stale = _lastClaimsRead == null ||
+        DateTime.now().difference(_lastClaimsRead!) > const Duration(seconds: 60);
+    if (!requested && !stale) return;
+    unawaited(_refreshProfile(bustCache: requested));
+  }
+
+  /// Re-mints the access token (which - per [AuthService] - also persists a
+  /// fresh id token) and re-reads its claims, the same claims [_bootstrap]
+  /// reads on first launch. Called on resume so a picture uploaded on the
+  /// external Keycloak avatar page shows up without an app restart.
+  Future<void> _refreshProfile({required bool bustCache}) async {
+    ProfileRefreshRequests.clear();
+    await AuthService.refreshAccessToken();
+    final claims = await AuthService.getIdTokenClaims();
+    _lastClaimsRead = DateTime.now();
+    if (mounted && claims != null) {
+      var picture = claims['picture'] as String?;
+      // The Keycloak avatar URL is stable per user, so NetworkImage would
+      // keep serving the cached image unless the URL itself changes.
+      if (bustCache && picture != null && picture.isNotEmpty) {
+        final sep = picture.contains('?') ? '&' : '?';
+        picture = '$picture${sep}v=${DateTime.now().millisecondsSinceEpoch}';
+      }
+      setState(() {
+        _pictureUrl = picture;
+        _userName = claims['name'] as String?;
+        _userEmail = claims['email'] as String?;
+      });
+    }
+    try {
+      await ApiClient.instance.api.getAuthApi().apiAuthSyncGet();
+    } catch (_) {
+      // Best-effort - the local claims already reflect the new picture.
+    }
   }
 
   void _onTabRequested() {
@@ -78,6 +126,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
     }
 
     final claims = await AuthService.getIdTokenClaims();
+    _lastClaimsRead = DateTime.now();
     if (mounted && claims != null) {
       setState(() {
         _pictureUrl = claims['picture'] as String?;

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import '../../services/active_account_service.dart';
 import '../../services/app_mode_service.dart';
 import '../../services/auth_service.dart';
 import '../../services/private_account_store.dart';
+import '../../services/profile_refresh_requests.dart';
 import '../../services/school_data_service.dart';
 import '../../services/theme_service.dart';
 import 'notification_settings_section.dart';
@@ -145,7 +146,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (mounted) {
         showFToast(context: context, title: const Text("Couldn't open the picture page"));
       }
+      return;
     }
+    ProfileRefreshRequests.request();
   }
 
   Future<void> _openServerDialog() async {

--- a/test/profile_refresh_requests_test.dart
+++ b/test/profile_refresh_requests_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:schuly/services/profile_refresh_requests.dart';
+
+void main() {
+  setUp(() => ProfileRefreshRequests.clear());
+
+  group('ProfileRefreshRequests', () {
+    test('starts clear', () {
+      expect(ProfileRefreshRequests.pending.value, isFalse);
+    });
+
+    test('request() sets the flag', () {
+      ProfileRefreshRequests.request();
+      expect(ProfileRefreshRequests.pending.value, isTrue);
+    });
+
+    test('clear() resets the flag', () {
+      ProfileRefreshRequests.request();
+      ProfileRefreshRequests.clear();
+      expect(ProfileRefreshRequests.pending.value, isFalse);
+    });
+
+    test('notifies listeners on request and clear', () {
+      final events = <bool>[];
+      void listener() => events.add(ProfileRefreshRequests.pending.value);
+      ProfileRefreshRequests.pending.addListener(listener);
+      addTearDown(
+        () => ProfileRefreshRequests.pending.removeListener(listener),
+      );
+
+      ProfileRefreshRequests.request();
+      ProfileRefreshRequests.clear();
+
+      expect(events, [true, false]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Set a `ProfileRefreshRequests` flag (`lib/services/profile_refresh_requests.dart`) when Settings launches the external Keycloak avatar page
- `DashboardScreen` now observes app lifecycle; on resume, if the flag is set or the last claims read is older than 60s, it refreshes the access token, re-reads the ID token claims, and updates the header/account avatar
- The refreshed picture URL gets a `?v=<millis>` cache-busting query when the flag triggered the refresh, since `NetworkImage` would otherwise keep serving the old avatar for the stable Keycloak URL
- Also calls `GET /api/Auth/sync` on refresh so the backend's stored profile picture URL stays in sync
- Added a unit test for the new notifier; a full widget test of the resumed-dashboard behavior was skipped since `AuthService`/`ApiClient` are static singletons with no injection seam

Closes #507